### PR TITLE
refactor: extract Field module from Form

### DIFF
--- a/.changeset/extract-field-module.md
+++ b/.changeset/extract-field-module.md
@@ -1,0 +1,12 @@
+---
+"@lucas-barake/effect-form": minor
+"@lucas-barake/effect-form-react": minor
+---
+
+Extract Field module from Form
+
+- Add dedicated `Field` module with field definitions, constructors, type helpers, and guards
+- `Field.makeField`, `Field.makeArrayField` for creating field definitions
+- `Field.isFieldDef`, `Field.isArrayFieldDef` type guards
+- `Field.getDefaultEncodedValues`, `Field.createTouchedRecord` helpers
+- Re-export `Field` from `@lucas-barake/effect-form-react` for convenience

--- a/packages/form-react/src/FormReact.tsx
+++ b/packages/form-react/src/FormReact.tsx
@@ -4,7 +4,8 @@
 import { RegistryContext, useAtom, useAtomSet, useAtomSubscribe, useAtomValue } from "@effect-atom/atom-react"
 import * as Atom from "@effect-atom/atom/Atom"
 import type * as Result from "@effect-atom/atom/Result"
-import { Form, FormAtoms, Mode, Validation } from "@lucas-barake/effect-form"
+import { Field, FormAtoms, Mode, Validation } from "@lucas-barake/effect-form"
+import type * as Form from "@lucas-barake/effect-form/Form"
 import { getNestedValue, isPathOrParentDirty, schemaPathToFieldPath } from "@lucas-barake/effect-form/internal/path"
 import * as Cause from "effect/Cause"
 import type * as Effect from "effect/Effect"
@@ -51,9 +52,9 @@ export type ArrayItemComponentMap<S extends Schema.Schema.Any> = S extends Schem
  * @since 1.0.0
  * @category Models
  */
-export type FieldComponentMap<TFields extends Form.FieldsRecord> = {
-  readonly [K in keyof TFields]: TFields[K] extends Form.FieldDef<any, infer S> ? React.FC<FieldComponentProps<S>>
-    : TFields[K] extends Form.ArrayFieldDef<any, infer S> ? ArrayItemComponentMap<S>
+export type FieldComponentMap<TFields extends Field.FieldsRecord> = {
+  readonly [K in keyof TFields]: TFields[K] extends Field.FieldDef<any, infer S> ? React.FC<FieldComponentProps<S>>
+    : TFields[K] extends Field.ArrayFieldDef<any, infer S> ? ArrayItemComponentMap<S>
     : never
 }
 
@@ -63,7 +64,7 @@ export type FieldComponentMap<TFields extends Form.FieldsRecord> = {
  * @since 1.0.0
  * @category Models
  */
-export type FieldRefs<TFields extends Form.FieldsRecord> = FormAtoms.FieldRefs<TFields>
+export type FieldRefs<TFields extends Field.FieldsRecord> = FormAtoms.FieldRefs<TFields>
 
 /**
  * Operations available for array fields.
@@ -85,14 +86,14 @@ export interface ArrayFieldOperations<TItem> {
  * @since 1.0.0
  * @category Models
  */
-export interface SubscribeState<TFields extends Form.FieldsRecord> {
-  readonly values: Form.EncodedFromFields<TFields>
+export interface SubscribeState<TFields extends Field.FieldsRecord> {
+  readonly values: Field.EncodedFromFields<TFields>
   readonly isDirty: boolean
   readonly submitResult: Result.Result<unknown, unknown>
   readonly submit: () => void
   readonly reset: () => void
   readonly setValue: <S>(field: Form.Field<S>, update: S | ((prev: S) => S)) => void
-  readonly setValues: (values: Form.EncodedFromFields<TFields>) => void
+  readonly setValues: (values: Field.EncodedFromFields<TFields>) => void
 }
 
 /**
@@ -102,14 +103,14 @@ export interface SubscribeState<TFields extends Form.FieldsRecord> {
  * @since 1.0.0
  * @category Models
  */
-export type BuiltForm<TFields extends Form.FieldsRecord, R> = {
+export type BuiltForm<TFields extends Field.FieldsRecord, R> = {
   readonly atom: Atom.Writable<Option.Option<Form.FormState<TFields>>, Option.Option<Form.FormState<TFields>>>
-  readonly schema: Schema.Schema<Form.DecodedFromFields<TFields>, Form.EncodedFromFields<TFields>, R>
+  readonly schema: Schema.Schema<Field.DecodedFromFields<TFields>, Field.EncodedFromFields<TFields>, R>
   readonly fields: FieldRefs<TFields>
 
   readonly Form: React.FC<{
-    readonly defaultValues: Form.EncodedFromFields<TFields>
-    readonly onSubmit: Atom.AtomResultFn<Form.DecodedFromFields<TFields>, unknown, unknown>
+    readonly defaultValues: Field.EncodedFromFields<TFields>
+    readonly onSubmit: Atom.AtomResultFn<Field.DecodedFromFields<TFields>, unknown, unknown>
     readonly children: React.ReactNode
   }>
 
@@ -122,19 +123,19 @@ export type BuiltForm<TFields extends Form.FieldsRecord, R> = {
     readonly reset: () => void
     readonly isDirty: boolean
     readonly submitResult: Result.Result<unknown, unknown>
-    readonly values: Form.EncodedFromFields<TFields>
+    readonly values: Field.EncodedFromFields<TFields>
     readonly setValue: <S>(field: Form.Field<S>, update: S | ((prev: S) => S)) => void
-    readonly setValues: (values: Form.EncodedFromFields<TFields>) => void
+    readonly setValues: (values: Field.EncodedFromFields<TFields>) => void
   }
 
   readonly submit: <A, E>(
-    fn: (values: Form.DecodedFromFields<TFields>, get: Atom.FnContext) => Effect.Effect<A, E, R>,
-  ) => Atom.AtomResultFn<Form.DecodedFromFields<TFields>, A, E>
+    fn: (values: Field.DecodedFromFields<TFields>, get: Atom.FnContext) => Effect.Effect<A, E, R>,
+  ) => Atom.AtomResultFn<Field.DecodedFromFields<TFields>, A, E>
 } & FieldComponents<TFields>
 
-type FieldComponents<TFields extends Form.FieldsRecord> = {
-  readonly [K in keyof TFields]: TFields[K] extends Form.FieldDef<any, any> ? React.FC
-    : TFields[K] extends Form.ArrayFieldDef<any, infer S> ? ArrayFieldComponent<S>
+type FieldComponents<TFields extends Field.FieldsRecord> = {
+  readonly [K in keyof TFields]: TFields[K] extends Field.FieldDef<any, any> ? React.FC
+    : TFields[K] extends Field.ArrayFieldDef<any, infer S> ? ArrayFieldComponent<S>
     : never
 }
 
@@ -161,7 +162,7 @@ const AutoSubmitContext = createContext<(() => void) | null>(null)
 
 const makeFieldComponent = <S extends Schema.Schema.Any>(
   fieldKey: string,
-  fieldDef: Form.FieldDef<string, S>,
+  fieldDef: Field.FieldDef<string, S>,
   crossFieldErrorsAtom: Atom.Writable<Map<string, string>, Map<string, string>>,
   submitCountAtom: Atom.Atom<number>,
   dirtyFieldsAtom: Atom.Atom<ReadonlySet<string>>,
@@ -280,7 +281,7 @@ const makeFieldComponent = <S extends Schema.Schema.Any>(
 
 const makeArrayFieldComponent = <S extends Schema.Schema.Any>(
   fieldKey: string,
-  def: Form.ArrayFieldDef<string, S>,
+  def: Field.ArrayFieldDef<string, S>,
   stateAtom: Atom.Writable<Option.Option<Form.FormState<any>>, Option.Option<Form.FormState<any>>>,
   crossFieldErrorsAtom: Atom.Writable<Map<string, string>, Map<string, string>>,
   submitCountAtom: Atom.Atom<number>,
@@ -383,7 +384,7 @@ const makeArrayFieldComponent = <S extends Schema.Schema.Any>(
     for (const prop of ast.propertySignatures) {
       const itemKey = prop.name as string
       const itemSchema = { ast: prop.type } as Schema.Schema.Any
-      const itemDef = Form.makeField(itemKey, itemSchema)
+      const itemDef = Field.makeField(itemKey, itemSchema)
       const itemComponent = (componentMap as Record<string, React.FC<FieldComponentProps<any>>>)[itemKey]
       itemFieldComponents[itemKey] = makeFieldComponent(
         itemKey,
@@ -414,7 +415,7 @@ const makeArrayFieldComponent = <S extends Schema.Schema.Any>(
   }) as ArrayFieldComponent<S>
 }
 
-const makeFieldComponents = <TFields extends Form.FieldsRecord>(
+const makeFieldComponents = <TFields extends Field.FieldsRecord>(
   fields: TFields,
   stateAtom: Atom.Writable<Option.Option<Form.FormState<TFields>>, Option.Option<Form.FormState<TFields>>>,
   crossFieldErrorsAtom: Atom.Writable<Map<string, string>, Map<string, string>>,
@@ -432,11 +433,11 @@ const makeFieldComponents = <TFields extends Form.FieldsRecord>(
   const components: Record<string, any> = {}
 
   for (const [key, def] of Object.entries(fields)) {
-    if (Form.isArrayFieldDef(def)) {
+    if (Field.isArrayFieldDef(def)) {
       const arrayComponentMap = (componentMap as Record<string, any>)[key]
       components[key] = makeArrayFieldComponent(
         key,
-        def as Form.ArrayFieldDef<string, Schema.Schema.Any>,
+        def as Field.ArrayFieldDef<string, Schema.Schema.Any>,
         stateAtom,
         crossFieldErrorsAtom,
         submitCountAtom,
@@ -447,7 +448,7 @@ const makeFieldComponents = <TFields extends Form.FieldsRecord>(
         operations,
         arrayComponentMap,
       )
-    } else if (Form.isFieldDef(def)) {
+    } else if (Field.isFieldDef(def)) {
       const fieldComponent = (componentMap as Record<string, React.FC<FieldComponentProps<any>>>)[key]
       components[key] = makeFieldComponent(
         key,
@@ -514,7 +515,7 @@ const makeFieldComponents = <TFields extends Form.FieldsRecord>(
  * @since 1.0.0
  * @category Constructors
  */
-export const build = <TFields extends Form.FieldsRecord, R, ER = never>(
+export const build = <TFields extends Field.FieldsRecord, R, ER = never>(
   self: Form.FormBuilder<TFields, R>,
   options: {
     readonly runtime: Atom.AtomRuntime<R, ER>
@@ -548,8 +549,8 @@ export const build = <TFields extends Form.FieldsRecord, R, ER = never>(
   } = formAtoms
 
   const FormComponent: React.FC<{
-    readonly defaultValues: Form.EncodedFromFields<TFields>
-    readonly onSubmit: Atom.AtomResultFn<Form.DecodedFromFields<TFields>, unknown, unknown>
+    readonly defaultValues: Field.EncodedFromFields<TFields>
+    readonly onSubmit: Atom.AtomResultFn<Field.DecodedFromFields<TFields>, unknown, unknown>
     readonly children: React.ReactNode
   }> = ({ children, defaultValues, onSubmit }) => {
     const registry = React.useContext(RegistryContext)
@@ -693,7 +694,7 @@ export const build = <TFields extends Form.FieldsRecord, R, ER = never>(
       })
     }, [setFormState, setCrossFieldErrors])
 
-    const setValues = React.useCallback((values: Form.EncodedFromFields<TFields>) => {
+    const setValues = React.useCallback((values: Field.EncodedFromFields<TFields>) => {
       setFormState((prev) => {
         if (Option.isNone(prev)) return prev
         return Option.some(operations.setFormValues(prev.value, values))
@@ -714,8 +715,8 @@ export const build = <TFields extends Form.FieldsRecord, R, ER = never>(
   }
 
   const submitHelper = <A, E>(
-    fn: (values: Form.DecodedFromFields<TFields>, get: Atom.FnContext) => Effect.Effect<A, E, R>,
-  ) => runtime.fn<Form.DecodedFromFields<TFields>>()(fn) as Atom.AtomResultFn<Form.DecodedFromFields<TFields>, A, E>
+    fn: (values: Field.DecodedFromFields<TFields>, get: Atom.FnContext) => Effect.Effect<A, E, R>,
+  ) => runtime.fn<Field.DecodedFromFields<TFields>>()(fn) as Atom.AtomResultFn<Field.DecodedFromFields<TFields>, A, E>
 
   const fieldComponents = makeFieldComponents(
     fields,

--- a/packages/form-react/src/index.ts
+++ b/packages/form-react/src/index.ts
@@ -6,6 +6,12 @@
  * @since 1.0.0
  * @category re-exports
  */
+export * as Field from "@lucas-barake/effect-form/Field"
+
+/**
+ * @since 1.0.0
+ * @category re-exports
+ */
 export * as Form from "@lucas-barake/effect-form/Form"
 
 /**

--- a/packages/form-react/test/FormReact.test.tsx
+++ b/packages/form-react/test/FormReact.test.tsx
@@ -1,7 +1,7 @@
 import { useAtomValue } from "@effect-atom/atom-react"
 import * as Atom from "@effect-atom/atom/Atom"
 import * as Result from "@effect-atom/atom/Result"
-import { Form, FormReact } from "@lucas-barake/effect-form-react"
+import { Field, Form, FormReact } from "@lucas-barake/effect-form-react"
 import { render, screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import * as Context from "effect/Context"
@@ -35,7 +35,7 @@ const TextInput: React.FC<FormReact.FieldComponentProps<typeof Schema.String>> =
 describe("FormReact.build", () => {
   describe("Form Component", () => {
     it("initializes with default values", () => {
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -59,7 +59,7 @@ describe("FormReact.build", () => {
     it("updates value on change", async () => {
       const user = userEvent.setup()
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -85,7 +85,7 @@ describe("FormReact.build", () => {
       const user = userEvent.setup()
 
       const NonEmpty = Schema.String.pipe(Schema.minLength(1, { message: () => "Required" }))
-      const NameField = Form.makeField("name", NonEmpty)
+      const NameField = Field.makeField("name", NonEmpty)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -114,7 +114,7 @@ describe("FormReact.build", () => {
 
   describe("useForm hook", () => {
     it("returns isDirty = false when values match initial", () => {
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -145,7 +145,7 @@ describe("FormReact.build", () => {
     it("returns isDirty = true when values differ from initial", async () => {
       const user = userEvent.setup()
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -180,7 +180,7 @@ describe("FormReact.build", () => {
       const user = userEvent.setup()
       const submitHandler = vi.fn()
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const runtime = createRuntime()
@@ -215,8 +215,8 @@ describe("FormReact.build", () => {
     it("renders multiple fields correctly", async () => {
       const user = userEvent.setup()
 
-      const FirstNameField = Form.makeField("firstName", Schema.String)
-      const LastNameField = Form.makeField("lastName", Schema.String)
+      const FirstNameField = Field.makeField("firstName", Schema.String)
+      const LastNameField = Field.makeField("lastName", Schema.String)
       const formBuilder = Form.empty.addField(FirstNameField).addField(LastNameField)
 
       const NamedInput: React.FC<FormReact.FieldComponentProps<typeof Schema.String> & { name: string }> = ({
@@ -271,8 +271,8 @@ describe("FormReact.build", () => {
     it("renders array field with items", async () => {
       const user = userEvent.setup()
 
-      const TitleField = Form.makeField("title", Schema.String)
-      const ItemsArrayField = Form.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+      const TitleField = Field.makeField("title", Schema.String)
+      const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
       const formBuilder = Form.empty.addField(TitleField).addField(ItemsArrayField)
 
       const TitleInput: React.FC<FormReact.FieldComponentProps<typeof Schema.String>> = ({
@@ -349,7 +349,7 @@ describe("FormReact.build", () => {
     it("remove() removes item at specified index", async () => {
       const user = userEvent.setup()
 
-      const ItemsArrayField = Form.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+      const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
       const formBuilder = Form.empty.addField(ItemsArrayField)
 
       const ItemNameInput: React.FC<FormReact.FieldComponentProps<typeof Schema.String>> = ({
@@ -416,7 +416,7 @@ describe("FormReact.build", () => {
     it("swap() exchanges items at two indices", async () => {
       const user = userEvent.setup()
 
-      const ItemsArrayField = Form.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+      const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
       const formBuilder = Form.empty.addField(ItemsArrayField)
 
       const ItemNameInput: React.FC<FormReact.FieldComponentProps<typeof Schema.String>> = ({
@@ -480,7 +480,7 @@ describe("FormReact.build", () => {
     it("move() relocates item from one index to another", async () => {
       const user = userEvent.setup()
 
-      const ItemsArrayField = Form.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+      const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
       const formBuilder = Form.empty.addField(ItemsArrayField)
 
       const ItemNameInput: React.FC<FormReact.FieldComponentProps<typeof Schema.String>> = ({
@@ -540,7 +540,7 @@ describe("FormReact.build", () => {
     it("Item render prop provides remove function", async () => {
       const user = userEvent.setup()
 
-      const ItemsArrayField = Form.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+      const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
       const formBuilder = Form.empty.addField(ItemsArrayField)
 
       const ItemNameInput: React.FC<FormReact.FieldComponentProps<typeof Schema.String>> = ({
@@ -610,7 +610,7 @@ describe("FormReact.build", () => {
         Schema.filterEffect(() => Effect.succeed(true).pipe(Effect.delay("10 millis"))),
       )
 
-      const EmailField = Form.makeField("email", AsyncEmail)
+      const EmailField = Field.makeField("email", AsyncEmail)
       const formBuilder = Form.empty.addField(EmailField)
 
       const runtime = createRuntime()
@@ -665,7 +665,7 @@ describe("FormReact.build", () => {
         </div>
       )
 
-      const AsyncFieldDef = Form.makeField("asyncField", AsyncField)
+      const AsyncFieldDef = Field.makeField("asyncField", AsyncField)
       const formBuilder = Form.empty.addField(AsyncFieldDef)
 
       const runtime = createRuntime()
@@ -739,8 +739,8 @@ describe("FormReact.build", () => {
         </div>
       )
 
-      const PasswordField = Form.makeField("password", Schema.String)
-      const ConfirmPasswordField = Form.makeField("confirmPassword", Schema.String)
+      const PasswordField = Field.makeField("password", Schema.String)
+      const ConfirmPasswordField = Field.makeField("confirmPassword", Schema.String)
       const formBuilder = Form.empty.addField(PasswordField).addField(ConfirmPasswordField)
         .refine((values) => {
           if (values.password !== values.confirmPassword) {
@@ -802,7 +802,7 @@ describe("FormReact.build", () => {
         </div>
       )
 
-      const UsernameField = Form.makeField("username", Schema.String)
+      const UsernameField = Field.makeField("username", Schema.String)
       const formBuilder = Form.empty
         .addField(UsernameField)
         .refineEffect((values) =>
@@ -871,7 +871,7 @@ describe("FormReact.build", () => {
         </div>
       )
 
-      const UsernameField = Form.makeField("username", Schema.String)
+      const UsernameField = Field.makeField("username", Schema.String)
       const formBuilder = Form.empty
         .addField(UsernameField)
         .refineEffect((values) =>
@@ -941,8 +941,8 @@ describe("FormReact.build", () => {
         <FieldInput {...props} testId="fieldB" />
       )
 
-      const FieldAField = Form.makeField("fieldA", Schema.String)
-      const FieldBField = Form.makeField("fieldB", Schema.String)
+      const FieldAField = Field.makeField("fieldA", Schema.String)
+      const FieldBField = Field.makeField("fieldB", Schema.String)
       const formBuilder = Form.empty
         .addField(FieldAField)
         .addField(FieldBField)
@@ -1030,8 +1030,8 @@ describe("FormReact.build", () => {
         <FieldInput {...props} testId="confirm" />
       )
 
-      const PasswordField = Form.makeField("password", Schema.String)
-      const ConfirmField = Form.makeField("confirm", Schema.String)
+      const PasswordField = Field.makeField("password", Schema.String)
+      const ConfirmField = Field.makeField("confirm", Schema.String)
       const formBuilder = Form.empty
         .addField(PasswordField)
         .addField(ConfirmField)
@@ -1101,7 +1101,7 @@ describe("FormReact.build", () => {
         name: Schema.String.pipe(Schema.minLength(3, { message: () => "Name must be at least 3 characters" })),
       })
 
-      const ItemsArrayField = Form.makeArrayField("items", ItemSchema)
+      const ItemsArrayField = Field.makeArrayField("items", ItemSchema)
       const formBuilder = Form.empty.addField(ItemsArrayField)
 
       const runtime = createRuntime()
@@ -1150,7 +1150,7 @@ describe("FormReact.build", () => {
       const user = userEvent.setup()
 
       const NonEmpty = Schema.String.pipe(Schema.minLength(1, { message: () => "Required" }))
-      const NameField = Form.makeField("name", NonEmpty)
+      const NameField = Field.makeField("name", NonEmpty)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -1183,7 +1183,7 @@ describe("FormReact.build", () => {
       const user = userEvent.setup()
 
       const NonEmpty = Schema.String.pipe(Schema.minLength(1, { message: () => "Required" }))
-      const NameField = Form.makeField("name", NonEmpty)
+      const NameField = Field.makeField("name", NonEmpty)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -1214,7 +1214,7 @@ describe("FormReact.build", () => {
       const user = userEvent.setup()
 
       const NonEmpty = Schema.String.pipe(Schema.minLength(1, { message: () => "Required" }))
-      const NameField = Form.makeField("name", NonEmpty)
+      const NameField = Field.makeField("name", NonEmpty)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -1251,7 +1251,7 @@ describe("FormReact.build", () => {
     it("captures error when onSubmit Effect fails", async () => {
       const user = userEvent.setup()
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const runtime = createRuntime()
@@ -1290,7 +1290,7 @@ describe("FormReact.build", () => {
 
   describe("Subscribe component", () => {
     it("exposes submitResult with initial state", () => {
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -1324,7 +1324,7 @@ describe("FormReact.build", () => {
     it("exposes submitResult.waiting during submission", async () => {
       const user = userEvent.setup()
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const runtime = createRuntime()
@@ -1366,7 +1366,7 @@ describe("FormReact.build", () => {
       const user = userEvent.setup()
 
       const NonEmpty = Schema.String.pipe(Schema.minLength(1, { message: () => "Required" }))
-      const NameField = Form.makeField("name", NonEmpty)
+      const NameField = Field.makeField("name", NonEmpty)
       const formBuilder = Form.empty.addField(NameField)
 
       const runtime = createRuntime()
@@ -1402,7 +1402,7 @@ describe("FormReact.build", () => {
     it("updates isDirty when values change", async () => {
       const user = userEvent.setup()
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -1440,7 +1440,7 @@ describe("FormReact.build", () => {
     it("form does not reinitialize on rerender (mount-only initialization)", async () => {
       const user = userEvent.setup()
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -1486,7 +1486,7 @@ describe("FormReact.build", () => {
     it("form reinitializes when using React key to force remount", async () => {
       const user = userEvent.setup()
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -1533,7 +1533,7 @@ describe("FormReact.build", () => {
     it("isDirty becomes false when value returns to initial", async () => {
       const user = userEvent.setup()
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -1574,7 +1574,7 @@ describe("FormReact.build", () => {
     it("isDirty remains after successful submission", async () => {
       const user = userEvent.setup()
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const runtime = createRuntime()
@@ -1619,7 +1619,7 @@ describe("FormReact.build", () => {
     it("reset() restores form to initial values", async () => {
       const user = userEvent.setup()
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const runtime = createRuntime()
@@ -1679,7 +1679,7 @@ describe("FormReact.build", () => {
     it("tracks submitCount through form atom", async () => {
       const user = userEvent.setup()
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const runtime = createRuntime()
@@ -1720,7 +1720,7 @@ describe("FormReact.build", () => {
 
   describe("setValue", () => {
     it("updates a scalar field value using Field identity", async () => {
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -1763,7 +1763,7 @@ describe("FormReact.build", () => {
     })
 
     it("updates value using functional callback (prev => next)", async () => {
-      const CountField = Form.makeField("count", Schema.NumberFromString)
+      const CountField = Field.makeField("count", Schema.NumberFromString)
       const formBuilder = Form.empty.addField(CountField)
 
       const NumberInput: React.FC<FormReact.FieldComponentProps<typeof Schema.NumberFromString>> = ({
@@ -1823,7 +1823,7 @@ describe("FormReact.build", () => {
     })
 
     it("updates array items using functional callback (filter)", async () => {
-      const ItemsArrayField = Form.makeArrayField(
+      const ItemsArrayField = Field.makeArrayField(
         "items",
         Schema.Struct({
           id: Schema.NumberFromString,
@@ -1920,7 +1920,7 @@ describe("FormReact.build", () => {
     })
 
     it("marks field as dirty when value differs from initial", async () => {
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -1962,7 +1962,7 @@ describe("FormReact.build", () => {
     })
 
     it("marks field as clean when value returns to initial", async () => {
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -2012,8 +2012,8 @@ describe("FormReact.build", () => {
     })
 
     it("clears stale nested dirty paths when parent object is replaced", async () => {
-      const NameField = Form.makeField("name", Schema.String)
-      const AddressesArrayField = Form.makeArrayField(
+      const NameField = Field.makeField("name", Schema.String)
+      const AddressesArrayField = Field.makeArrayField(
         "addresses",
         Schema.Struct({
           street: Schema.String,
@@ -2151,7 +2151,7 @@ describe("FormReact.build", () => {
         </div>
       )
 
-      const NameField = Form.makeField("name", NonEmpty)
+      const NameField = Field.makeField("name", NonEmpty)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -2194,7 +2194,7 @@ describe("FormReact.build", () => {
     it("triggers validation in mounted components (onChange mode)", async () => {
       const NonEmpty = Schema.String.pipe(Schema.minLength(1, { message: () => "Required" }))
 
-      const NameField = Form.makeField("name", NonEmpty)
+      const NameField = Field.makeField("name", NonEmpty)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -2241,8 +2241,8 @@ describe("FormReact.build", () => {
     })
 
     it("clears cross-field errors for the affected path", async () => {
-      const PasswordField = Form.makeField("password", Schema.String)
-      const ConfirmPasswordField = Form.makeField("confirmPassword", Schema.String)
+      const PasswordField = Field.makeField("password", Schema.String)
+      const ConfirmPasswordField = Field.makeField("confirmPassword", Schema.String)
       const formBuilder = Form.empty
         .addField(PasswordField)
         .addField(ConfirmPasswordField)
@@ -2340,8 +2340,8 @@ describe("FormReact.build", () => {
 
   describe("setValues", () => {
     it("replaces entire form state", async () => {
-      const FirstNameField = Form.makeField("firstName", Schema.String)
-      const LastNameField = Form.makeField("lastName", Schema.String)
+      const FirstNameField = Field.makeField("firstName", Schema.String)
+      const LastNameField = Field.makeField("lastName", Schema.String)
       const formBuilder = Form.empty
         .addField(FirstNameField)
         .addField(LastNameField)
@@ -2423,8 +2423,8 @@ describe("FormReact.build", () => {
     })
 
     it("recalculates dirty state for all fields (global reset)", async () => {
-      const FirstNameField = Form.makeField("firstName", Schema.String)
-      const LastNameField = Form.makeField("lastName", Schema.String)
+      const FirstNameField = Field.makeField("firstName", Schema.String)
+      const LastNameField = Field.makeField("lastName", Schema.String)
       const formBuilder = Form.empty
         .addField(FirstNameField)
         .addField(LastNameField)
@@ -2524,8 +2524,8 @@ describe("FormReact.build", () => {
     })
 
     it("clears ALL cross-field errors", async () => {
-      const PasswordField = Form.makeField("password", Schema.String)
-      const ConfirmPasswordField = Form.makeField("confirmPassword", Schema.String)
+      const PasswordField = Field.makeField("password", Schema.String)
+      const ConfirmPasswordField = Field.makeField("confirmPassword", Schema.String)
       const formBuilder = Form.empty
         .addField(PasswordField)
         .addField(ConfirmPasswordField)
@@ -2639,7 +2639,7 @@ describe("FormReact.build", () => {
         </div>
       )
 
-      const NameField = Form.makeField("name", NonEmpty)
+      const NameField = Field.makeField("name", NonEmpty)
       const formBuilder = Form.empty.addField(NameField)
 
       const form = FormReact.build(formBuilder, {
@@ -2708,7 +2708,7 @@ describe("FormReact.build", () => {
         </div>
       )
 
-      const ItemsArrayField = Form.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+      const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
 
       const formBuilder = Form.empty.addField(ItemsArrayField)
         .refine((values) => {
@@ -2805,7 +2805,7 @@ describe("FormReact.build", () => {
         </div>
       )
 
-      const ItemsArrayField = Form.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+      const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
 
       const formBuilder = Form.empty.addField(ItemsArrayField)
         .refine((values) => {
@@ -2884,7 +2884,7 @@ describe("FormReact.build", () => {
         </div>
       )
 
-      const ItemsArrayField = Form.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+      const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
 
       const formBuilder = Form.empty.addField(ItemsArrayField)
         .refineEffect((values) =>
@@ -2957,7 +2957,7 @@ describe("FormReact.build", () => {
         </div>
       )
 
-      const ItemsArrayField = Form.makeArrayField(
+      const ItemsArrayField = Field.makeArrayField(
         "items",
         Schema.Struct({
           name: Schema.String.pipe(Schema.minLength(3, { message: () => "Name must be at least 3 characters" })),

--- a/packages/form-react/test/internal/debounce-auto-submit.test.tsx
+++ b/packages/form-react/test/internal/debounce-auto-submit.test.tsx
@@ -1,5 +1,5 @@
 import * as Atom from "@effect-atom/atom/Atom"
-import { Form, FormReact } from "@lucas-barake/effect-form-react"
+import { Field, Form, FormReact } from "@lucas-barake/effect-form-react"
 import { render, screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import * as Effect from "effect/Effect"
@@ -36,14 +36,14 @@ const AgeInput: React.FC<FormReact.FieldComponentProps<typeof Schema.String>> = 
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-const NameField = Form.makeField("name", Schema.String)
-const NameFieldMinLength = Form.makeField(
+const NameField = Field.makeField("name", Schema.String)
+const NameFieldMinLength = Field.makeField(
   "name",
   Schema.String.pipe(
     Schema.minLength(5, { message: () => "Must be at least 5 characters" }),
   ),
 )
-const AgeField = Form.makeField("age", Schema.String)
+const AgeField = Field.makeField("age", Schema.String)
 
 describe("Debounce and Auto-Submit", () => {
   describe("Manual Submit Debounce", () => {

--- a/packages/form/src/Field.ts
+++ b/packages/form/src/Field.ts
@@ -1,0 +1,220 @@
+/**
+ * Field definitions for type-safe forms.
+ *
+ * @since 1.0.0
+ */
+import * as Schema from "effect/Schema"
+
+/**
+ * Unique identifier for Field instances.
+ *
+ * @since 1.0.0
+ * @category Symbols
+ */
+export const TypeId: unique symbol = Symbol.for("@lucas-barake/effect-form/Field")
+
+/**
+ * @since 1.0.0
+ * @category Symbols
+ */
+export type TypeId = typeof TypeId
+
+/**
+ * A scalar field definition containing the key and schema.
+ *
+ * @since 1.0.0
+ * @category Models
+ */
+export interface FieldDef<K extends string, S extends Schema.Schema.Any> {
+  readonly _tag: "field"
+  readonly key: K
+  readonly schema: S
+}
+
+/**
+ * An array field definition containing a schema for items.
+ *
+ * @since 1.0.0
+ * @category Models
+ */
+export interface ArrayFieldDef<K extends string, S extends Schema.Schema.Any> {
+  readonly _tag: "array"
+  readonly key: K
+  readonly itemSchema: S
+}
+
+/**
+ * Union of all field definition types.
+ *
+ * @since 1.0.0
+ * @category Models
+ */
+export type AnyFieldDef = FieldDef<string, Schema.Schema.Any> | ArrayFieldDef<string, Schema.Schema.Any>
+
+/**
+ * A record of field definitions.
+ *
+ * @since 1.0.0
+ * @category Models
+ */
+export type FieldsRecord = Record<string, AnyFieldDef>
+
+/**
+ * Checks if a field definition is an array field.
+ *
+ * @since 1.0.0
+ * @category Guards
+ */
+export const isArrayFieldDef = (def: AnyFieldDef): def is ArrayFieldDef<string, Schema.Schema.Any> =>
+  def._tag === "array"
+
+/**
+ * Checks if a field definition is a scalar field.
+ *
+ * @since 1.0.0
+ * @category Guards
+ */
+export const isFieldDef = (def: AnyFieldDef): def is FieldDef<string, Schema.Schema.Any> => def._tag === "field"
+
+/**
+ * Creates a scalar field definition.
+ *
+ * @example
+ * ```ts
+ * import * as Field from "@lucas-barake/effect-form/Field"
+ * import * as Schema from "effect/Schema"
+ *
+ * const NameField = Field.makeField("name", Schema.String)
+ * ```
+ *
+ * @since 1.0.0
+ * @category Constructors
+ */
+export const makeField = <K extends string, S extends Schema.Schema.Any>(
+  key: K,
+  schema: S,
+): FieldDef<K, S> => ({
+  _tag: "field",
+  key,
+  schema,
+})
+
+/**
+ * Creates an array field definition.
+ *
+ * @example
+ * ```ts
+ * import * as Field from "@lucas-barake/effect-form/Field"
+ * import * as Schema from "effect/Schema"
+ *
+ * // Array of primitives
+ * const TagsField = Field.makeArrayField("tags", Schema.String)
+ *
+ * // Array of objects
+ * const ItemsField = Field.makeArrayField("items", Schema.Struct({
+ *   name: Schema.String,
+ *   quantity: Schema.Number
+ * }))
+ * ```
+ *
+ * @since 1.0.0
+ * @category Constructors
+ */
+export const makeArrayField = <K extends string, S extends Schema.Schema.Any>(
+  key: K,
+  itemSchema: S,
+): ArrayFieldDef<K, S> => ({
+  _tag: "array",
+  key,
+  itemSchema,
+})
+
+/**
+ * Extracts the encoded (input) type from a fields record.
+ *
+ * @since 1.0.0
+ * @category Type Helpers
+ */
+export type EncodedFromFields<T extends FieldsRecord> = {
+  readonly [K in keyof T]: T[K] extends FieldDef<any, infer S> ? Schema.Schema.Encoded<S>
+    : T[K] extends ArrayFieldDef<any, infer S> ? ReadonlyArray<Schema.Schema.Encoded<S>>
+    : never
+}
+
+/**
+ * Extracts the decoded (output) type from a fields record.
+ *
+ * @since 1.0.0
+ * @category Type Helpers
+ */
+export type DecodedFromFields<T extends FieldsRecord> = {
+  readonly [K in keyof T]: T[K] extends FieldDef<any, infer S> ? Schema.Schema.Type<S>
+    : T[K] extends ArrayFieldDef<any, infer S> ? ReadonlyArray<Schema.Schema.Type<S>>
+    : never
+}
+
+/**
+ * Gets a default encoded value from a schema.
+ *
+ * @since 1.0.0
+ * @category Helpers
+ */
+export const getDefaultFromSchema = (schema: Schema.Schema.Any): unknown => {
+  const ast = schema.ast
+  switch (ast._tag) {
+    case "StringKeyword":
+    case "TemplateLiteral":
+      return ""
+    case "NumberKeyword":
+      return 0
+    case "BooleanKeyword":
+      return false
+    case "TypeLiteral": {
+      const result: Record<string, unknown> = {}
+      for (const prop of ast.propertySignatures) {
+        result[prop.name as string] = getDefaultFromSchema(Schema.make(prop.type))
+      }
+      return result
+    }
+    case "Transformation":
+      return getDefaultFromSchema(Schema.make(ast.from))
+    case "Refinement":
+      return getDefaultFromSchema(Schema.make(ast.from))
+    case "Suspend":
+      return getDefaultFromSchema(Schema.make(ast.f()))
+    default:
+      return ""
+  }
+}
+
+/**
+ * Gets default encoded values for a fields record.
+ *
+ * @since 1.0.0
+ * @category Helpers
+ */
+export const getDefaultEncodedValues = (fields: FieldsRecord): Record<string, unknown> => {
+  const result: Record<string, unknown> = {}
+  for (const [key, def] of Object.entries(fields)) {
+    if (isArrayFieldDef(def)) {
+      result[key] = []
+    } else {
+      result[key] = ""
+    }
+  }
+  return result
+}
+
+/**
+ * Creates a touched record with all fields set to the given value.
+ *
+ * @since 1.0.0
+ * @category Helpers
+ */
+export const createTouchedRecord = (fields: FieldsRecord, value: boolean): Record<string, boolean> => {
+  const result: Record<string, boolean> = {}
+  for (const key of Object.keys(fields)) {
+    result[key] = value
+  }
+  return result
+}

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -1,6 +1,11 @@
 /**
  * @since 1.0.0
  */
+export * as Field from "./Field.js"
+
+/**
+ * @since 1.0.0
+ */
 export * as Form from "./Form.js"
 
 /**

--- a/packages/form/test/Field.test.ts
+++ b/packages/form/test/Field.test.ts
@@ -1,0 +1,53 @@
+import * as Schema from "effect/Schema"
+import { describe, expect, it } from "vitest"
+import * as Field from "../src/Field.js"
+
+describe("Field", () => {
+  describe("getDefaultEncodedValues", () => {
+    it("returns empty string for scalar fields", () => {
+      const EmailField = Field.makeField("email", Schema.String)
+      const AgeField = Field.makeField("age", Schema.Number)
+
+      const fields = {
+        email: EmailField,
+        age: AgeField,
+      }
+
+      const defaults = Field.getDefaultEncodedValues(fields)
+
+      expect(defaults).toEqual({ email: "", age: "" })
+    })
+
+    it("returns empty array for array fields", () => {
+      const TitleField = Field.makeField("title", Schema.String)
+      const ItemsField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+
+      const fields = {
+        title: TitleField,
+        items: ItemsField,
+      }
+
+      const defaults = Field.getDefaultEncodedValues(fields)
+
+      expect(defaults).toEqual({ title: "", items: [] })
+    })
+  })
+
+  describe("type guards", () => {
+    it("isFieldDef identifies scalar field definitions", () => {
+      const EmailField = Field.makeField("email", Schema.String)
+      const ItemsField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+
+      expect(Field.isFieldDef(EmailField)).toBe(true)
+      expect(Field.isFieldDef(ItemsField)).toBe(false)
+    })
+
+    it("isArrayFieldDef identifies array field definitions", () => {
+      const EmailField = Field.makeField("email", Schema.String)
+      const ItemsField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+
+      expect(Field.isArrayFieldDef(ItemsField)).toBe(true)
+      expect(Field.isArrayFieldDef(EmailField)).toBe(false)
+    })
+  })
+})

--- a/packages/form/test/Form.test.ts
+++ b/packages/form/test/Form.test.ts
@@ -1,4 +1,4 @@
-import { Form } from "@lucas-barake/effect-form"
+import { Field, Form } from "@lucas-barake/effect-form"
 import * as Effect from "effect/Effect"
 import * as Schema from "effect/Schema"
 import { describe, expect, it } from "vitest"
@@ -11,7 +11,7 @@ describe("Form", () => {
     })
 
     it("addField adds a field to the builder", () => {
-      const EmailField = Form.makeField("email", Schema.String)
+      const EmailField = Field.makeField("email", Schema.String)
       const builder = Form.empty.addField(EmailField)
 
       expect(Form.isFormBuilder(builder)).toBe(true)
@@ -20,8 +20,8 @@ describe("Form", () => {
     })
 
     it("addArray adds an array field", () => {
-      const NameField = Form.makeField("name", Schema.String)
-      const AddressesField = Form.makeArrayField(
+      const NameField = Field.makeField("name", Schema.String)
+      const AddressesField = Field.makeArrayField(
         "addresses",
         Schema.Struct({
           street: Schema.String,
@@ -33,17 +33,17 @@ describe("Form", () => {
         .addField(AddressesField)
 
       expect(builder.fields.addresses._tag).toBe("array")
-      expect(Form.isArrayFieldDef(builder.fields.addresses)).toBe(true)
+      expect(Field.isArrayFieldDef(builder.fields.addresses)).toBe(true)
     })
 
     it("merge combines two form builders", () => {
-      const StreetField = Form.makeField("street", Schema.String)
-      const CityField = Form.makeField("city", Schema.String)
+      const StreetField = Field.makeField("street", Schema.String)
+      const CityField = Field.makeField("city", Schema.String)
       const addressFields = Form.empty
         .addField(StreetField)
         .addField(CityField)
 
-      const NameField = Form.makeField("name", Schema.String)
+      const NameField = Field.makeField("name", Schema.String)
       const builder = Form.empty
         .addField(NameField)
         .merge(addressFields)
@@ -54,8 +54,8 @@ describe("Form", () => {
 
   describe("buildSchema", () => {
     it("builds a Schema from simple fields", () => {
-      const EmailField = Form.makeField("email", Schema.String)
-      const AgeField = Form.makeField("age", Schema.Number)
+      const EmailField = Field.makeField("email", Schema.String)
+      const AgeField = Field.makeField("age", Schema.Number)
 
       const builder = Form.empty
         .addField(EmailField)
@@ -68,8 +68,8 @@ describe("Form", () => {
     })
 
     it("builds a Schema with array fields", () => {
-      const TitleField = Form.makeField("title", Schema.String)
-      const ItemsField = Form.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+      const TitleField = Field.makeField("title", Schema.String)
+      const ItemsField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
 
       const builder = Form.empty
         .addField(TitleField)
@@ -89,7 +89,7 @@ describe("Form", () => {
 
     it("validates with schema constraints", () => {
       const Email = Schema.String.pipe(Schema.pattern(/@/))
-      const EmailField = Form.makeField("email", Email)
+      const EmailField = Field.makeField("email", Email)
 
       const builder = Form.empty.addField(EmailField)
 
@@ -102,8 +102,8 @@ describe("Form", () => {
     })
 
     it("applies refinements in buildSchema", () => {
-      const PasswordField = Form.makeField("password", Schema.String)
-      const ConfirmPasswordField = Form.makeField("confirmPassword", Schema.String)
+      const PasswordField = Field.makeField("password", Schema.String)
+      const ConfirmPasswordField = Field.makeField("confirmPassword", Schema.String)
 
       const builder = Form.empty
         .addField(PasswordField)
@@ -124,7 +124,7 @@ describe("Form", () => {
     })
 
     it("applies async refinements with refineEffect", async () => {
-      const UsernameField = Form.makeField("username", Schema.String)
+      const UsernameField = Field.makeField("username", Schema.String)
 
       const builder = Form.empty
         .addField(UsernameField)
@@ -150,8 +150,8 @@ describe("Form", () => {
     })
 
     it("applies multiple chained refinements", () => {
-      const AField = Form.makeField("a", Schema.String)
-      const BField = Form.makeField("b", Schema.String)
+      const AField = Field.makeField("a", Schema.String)
+      const BField = Field.makeField("b", Schema.String)
 
       const builder = Form.empty
         .addField(AField)
@@ -177,53 +177,10 @@ describe("Form", () => {
     })
   })
 
-  describe("helpers", () => {
-    it("getDefaultEncodedValues returns empty values", () => {
-      const EmailField = Form.makeField("email", Schema.String)
-      const AgeField = Form.makeField("age", Schema.Number)
-
-      const builder = Form.empty
-        .addField(EmailField)
-        .addField(AgeField)
-
-      const defaults = Form.getDefaultEncodedValues(builder.fields)
-
-      expect(defaults).toEqual({ email: "", age: "" })
-    })
-
-    it("getDefaultEncodedValues returns empty array for array fields", () => {
-      const TitleField = Form.makeField("title", Schema.String)
-      const ItemsField = Form.makeArrayField("items", Schema.Struct({ name: Schema.String }))
-
-      const builder = Form.empty
-        .addField(TitleField)
-        .addField(ItemsField)
-
-      const defaults = Form.getDefaultEncodedValues(builder.fields)
-
-      expect(defaults).toEqual({ title: "", items: [] })
-    })
-  })
-
   describe("type guards", () => {
     it("isFormBuilder correctly identifies FormBuilder", () => {
       expect(Form.isFormBuilder(Form.empty)).toBe(true)
       expect(Form.isFormBuilder({})).toBe(false)
-    })
-
-    it("isFieldDef and isArrayFieldDef work correctly", () => {
-      const EmailField = Form.makeField("email", Schema.String)
-      const ItemsField = Form.makeArrayField("items", Schema.Struct({ name: Schema.String }))
-
-      const builder = Form.empty
-        .addField(EmailField)
-        .addField(ItemsField)
-
-      expect(Form.isFieldDef(builder.fields.email)).toBe(true)
-      expect(Form.isArrayFieldDef(builder.fields.email)).toBe(false)
-
-      expect(Form.isArrayFieldDef(builder.fields.items)).toBe(true)
-      expect(Form.isFieldDef(builder.fields.items)).toBe(false)
     })
   })
 })

--- a/packages/form/test/FormAtoms.test.ts
+++ b/packages/form/test/FormAtoms.test.ts
@@ -4,18 +4,19 @@ import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import * as Schema from "effect/Schema"
 import { describe, expect, it } from "vitest"
+import * as Field from "../src/Field.js"
 import * as Form from "../src/Form.js"
 import * as FormAtoms from "../src/FormAtoms.js"
 
 const makeTestForm = () => {
-  const NameField = Form.makeField("name", Schema.String)
-  const EmailField = Form.makeField("email", Schema.String)
+  const NameField = Field.makeField("name", Schema.String)
+  const EmailField = Field.makeField("email", Schema.String)
   return Form.empty.addField(NameField).addField(EmailField)
 }
 
 const makeArrayTestForm = () => {
-  const TitleField = Form.makeField("title", Schema.String)
-  const ItemsField = Form.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+  const TitleField = Field.makeField("title", Schema.String)
+  const ItemsField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
 
   return Form.empty.addField(TitleField).addField(ItemsField)
 }
@@ -266,9 +267,9 @@ describe("FormAtoms", () => {
   describe("operations.appendArrayItem", () => {
     it("adds item to array and updates dirty fields", () => {
       const runtime = Atom.runtime(Layer.empty)
-      const TitleField = Form.makeField("title", Schema.String)
+      const TitleField = Field.makeField("title", Schema.String)
       const ItemSchema = Schema.Struct({ name: Schema.String })
-      const ItemsField = Form.makeArrayField("items", ItemSchema)
+      const ItemsField = Field.makeArrayField("items", ItemSchema)
       const form = Form.empty.addField(TitleField).addField(ItemsField)
 
       const atoms = FormAtoms.make({ runtime, formBuilder: form })
@@ -292,9 +293,9 @@ describe("FormAtoms", () => {
 
     it("uses default values when no value provided", () => {
       const runtime = Atom.runtime(Layer.empty)
-      const TitleField = Form.makeField("title", Schema.String)
+      const TitleField = Field.makeField("title", Schema.String)
       const ItemSchema = Schema.Struct({ name: Schema.String })
-      const ItemsField = Form.makeArrayField("items", ItemSchema)
+      const ItemsField = Field.makeArrayField("items", ItemSchema)
       const form = Form.empty.addField(TitleField).addField(ItemsField)
 
       const atoms = FormAtoms.make({ runtime, formBuilder: form })


### PR DESCRIPTION
## Summary
- Create dedicated `Field` module with field definitions, type helpers, and guards
- Move `makeField`, `makeArrayField`, `isFieldDef`, `isArrayFieldDef` to Field module
- Update all imports across form and form-react packages
- Add `Field` re-export to form-react for convenience
- Update README with Field imports and PascalCase form naming convention
- Add section on subscribing to form state with `useAtomSubscribe`