### PR TITLE
fix: run changesets on workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - run: pnpm build
       - run: pnpm circular
       - name: Create Release Pull Request or Publish
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         id: changesets
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
## Summary
- Updated build workflow to also run changesets action on `workflow_dispatch` events
- This allows manually triggering version bumps when needed

## Test plan
- [x] Merge this PR (triggers push event + changesets)
- [x] Version Packages PR will be created automatically