### PR TITLE
feat: expose Path module as public API

### DIFF
--- a/.changeset/expose-path-module.md
+++ b/.changeset/expose-path-module.md
@@ -1,0 +1,10 @@
+---
+"@lucas-barake/effect-form": minor
+"@lucas-barake/effect-form-react": minor
+---
+
+Expose Path module as public API
+
+The Path utilities (`schemaPathToFieldPath`, `isPathUnderRoot`, `isPathOrParentDirty`, `getNestedValue`, `setNestedValue`) are now exported as a public module via `@lucas-barake/effect-form/Path`.
+
+This fixes an issue where `form-react` was importing from an unexported internal path, causing bundler errors in consuming applications.

--- a/packages/form-react/src/FormReact.tsx
+++ b/packages/form-react/src/FormReact.tsx
@@ -1,11 +1,8 @@
-/**
- * @since 1.0.0
- */
 import { RegistryContext, useAtom, useAtomSet, useAtomSubscribe, useAtomValue } from "@effect-atom/atom-react"
 import type * as Atom from "@effect-atom/atom/Atom"
 import { Field, FormAtoms, Mode, Validation } from "@lucas-barake/effect-form"
 import type * as FormBuilder from "@lucas-barake/effect-form/FormBuilder"
-import { getNestedValue, isPathOrParentDirty, isPathUnderRoot } from "@lucas-barake/effect-form/internal/path"
+import { getNestedValue, isPathOrParentDirty, isPathUnderRoot } from "@lucas-barake/effect-form/Path"
 import * as Cause from "effect/Cause"
 import type * as Effect from "effect/Effect"
 import * as Option from "effect/Option"
@@ -19,7 +16,6 @@ import { useDebounced } from "./internal/use-debounced.js"
 /**
  * Form-controlled state passed to field components.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface FieldState<S extends Schema.Schema.Any> {
@@ -36,7 +32,6 @@ export interface FieldState<S extends Schema.Schema.Any> {
  * Props passed to field components.
  * Contains form-controlled state in `field` and user-defined props in `props`.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface FieldComponentProps<
@@ -50,7 +45,6 @@ export interface FieldComponentProps<
 /**
  * Extracts the extra props type from a field component.
  *
- * @since 1.0.0
  * @category Type-level utilities
  */
 export type ExtractExtraProps<C> = C extends React.FC<FieldComponentProps<any, infer P>> ? P
@@ -61,7 +55,6 @@ export type ExtractExtraProps<C> = C extends React.FC<FieldComponentProps<any, i
  * - For Struct schemas: returns a map of field names to components
  * - For primitive schemas: returns a single component
  *
- * @since 1.0.0
  * @category Models
  */
 export type ArrayItemComponentMap<S extends Schema.Schema.Any> = S extends Schema.Struct<infer Fields> ? {
@@ -73,7 +66,6 @@ export type ArrayItemComponentMap<S extends Schema.Schema.Any> = S extends Schem
 /**
  * Maps field names to their React components.
  *
- * @since 1.0.0
  * @category Models
  */
 export type FieldComponentMap<TFields extends Field.FieldsRecord> = {
@@ -85,7 +77,6 @@ export type FieldComponentMap<TFields extends Field.FieldsRecord> = {
 /**
  * Maps field names to their type-safe Field references for setValue operations.
  *
- * @since 1.0.0
  * @category Models
  */
 export type FieldRefs<TFields extends Field.FieldsRecord> = FormAtoms.FieldRefs<TFields>
@@ -93,7 +84,6 @@ export type FieldRefs<TFields extends Field.FieldsRecord> = FormAtoms.FieldRefs<
 /**
  * Operations available for array fields.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface ArrayFieldOperations<TItem> {
@@ -108,7 +98,6 @@ export interface ArrayFieldOperations<TItem> {
  * The result of building a form, containing all components and utilities needed
  * for form rendering and submission.
  *
- * @since 1.0.0
  * @category Models
  */
 export type BuiltForm<
@@ -540,7 +529,6 @@ const makeFieldComponents = <
  * }
  * ```
  *
- * @since 1.0.0
  * @category Constructors
  */
 export const build = <
@@ -705,7 +693,6 @@ export const build = <
  * ))
  * ```
  *
- * @since 1.0.0
  * @category Constructors
  */
 export const forField = <K extends string, S extends Schema.Schema.Any>(

--- a/packages/form-react/src/index.ts
+++ b/packages/form-react/src/index.ts
@@ -1,13 +1,9 @@
 /**
  * Re-export commonly used modules from the core package.
- *
- * @since 1.0.0
  */
 export { Field, FormBuilder } from "@lucas-barake/effect-form"
 
 /**
  * React bindings for @lucas-barake/effect-form.
- *
- * @since 1.0.0
  */
 export * as FormReact from "./FormReact.js"

--- a/packages/form/src/Field.ts
+++ b/packages/form/src/Field.ts
@@ -1,20 +1,16 @@
 /**
  * Field definitions for type-safe forms.
- *
- * @since 1.0.0
  */
 import * as Schema from "effect/Schema"
 
 /**
  * Unique identifier for Field instances.
  *
- * @since 1.0.0
  * @category Symbols
  */
 export const TypeId: unique symbol = Symbol.for("@lucas-barake/effect-form/Field")
 
 /**
- * @since 1.0.0
  * @category Symbols
  */
 export type TypeId = typeof TypeId
@@ -22,7 +18,6 @@ export type TypeId = typeof TypeId
 /**
  * A scalar field definition containing the key and schema.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface FieldDef<K extends string, S extends Schema.Schema.Any> {
@@ -34,7 +29,6 @@ export interface FieldDef<K extends string, S extends Schema.Schema.Any> {
 /**
  * An array field definition containing a schema for items.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface ArrayFieldDef<K extends string, S extends Schema.Schema.Any> {
@@ -46,7 +40,6 @@ export interface ArrayFieldDef<K extends string, S extends Schema.Schema.Any> {
 /**
  * Union of all field definition types.
  *
- * @since 1.0.0
  * @category Models
  */
 export type AnyFieldDef = FieldDef<string, Schema.Schema.Any> | ArrayFieldDef<string, Schema.Schema.Any>
@@ -54,7 +47,6 @@ export type AnyFieldDef = FieldDef<string, Schema.Schema.Any> | ArrayFieldDef<st
 /**
  * A record of field definitions.
  *
- * @since 1.0.0
  * @category Models
  */
 export type FieldsRecord = Record<string, AnyFieldDef>
@@ -62,7 +54,6 @@ export type FieldsRecord = Record<string, AnyFieldDef>
 /**
  * Checks if a field definition is an array field.
  *
- * @since 1.0.0
  * @category Guards
  */
 export const isArrayFieldDef = (def: AnyFieldDef): def is ArrayFieldDef<string, Schema.Schema.Any> =>
@@ -71,7 +62,6 @@ export const isArrayFieldDef = (def: AnyFieldDef): def is ArrayFieldDef<string, 
 /**
  * Checks if a field definition is a scalar field.
  *
- * @since 1.0.0
  * @category Guards
  */
 export const isFieldDef = (def: AnyFieldDef): def is FieldDef<string, Schema.Schema.Any> => def._tag === "field"
@@ -87,7 +77,6 @@ export const isFieldDef = (def: AnyFieldDef): def is FieldDef<string, Schema.Sch
  * const NameField = Field.makeField("name", Schema.String)
  * ```
  *
- * @since 1.0.0
  * @category Constructors
  */
 export const makeField = <K extends string, S extends Schema.Schema.Any>(
@@ -117,7 +106,6 @@ export const makeField = <K extends string, S extends Schema.Schema.Any>(
  * }))
  * ```
  *
- * @since 1.0.0
  * @category Constructors
  */
 export const makeArrayField = <K extends string, S extends Schema.Schema.Any>(
@@ -132,7 +120,6 @@ export const makeArrayField = <K extends string, S extends Schema.Schema.Any>(
 /**
  * Extracts the encoded (input) type from a fields record.
  *
- * @since 1.0.0
  * @category Type Helpers
  */
 export type EncodedFromFields<T extends FieldsRecord> = {
@@ -144,7 +131,6 @@ export type EncodedFromFields<T extends FieldsRecord> = {
 /**
  * Extracts the decoded (output) type from a fields record.
  *
- * @since 1.0.0
  * @category Type Helpers
  */
 export type DecodedFromFields<T extends FieldsRecord> = {
@@ -156,7 +142,6 @@ export type DecodedFromFields<T extends FieldsRecord> = {
 /**
  * Gets a default encoded value from a schema.
  *
- * @since 1.0.0
  * @category Helpers
  */
 export const getDefaultFromSchema = (schema: Schema.Schema.Any): unknown => {
@@ -190,7 +175,6 @@ export const getDefaultFromSchema = (schema: Schema.Schema.Any): unknown => {
 /**
  * Gets default encoded values for a fields record.
  *
- * @since 1.0.0
  * @category Helpers
  */
 export const getDefaultEncodedValues = (fields: FieldsRecord): Record<string, unknown> => {
@@ -208,7 +192,6 @@ export const getDefaultEncodedValues = (fields: FieldsRecord): Record<string, un
 /**
  * Creates a touched record with all fields set to the given value.
  *
- * @since 1.0.0
  * @category Helpers
  */
 export const createTouchedRecord = (fields: FieldsRecord, value: boolean): Record<string, boolean> => {

--- a/packages/form/src/FormAtoms.ts
+++ b/packages/form/src/FormAtoms.ts
@@ -7,14 +7,13 @@ import * as Schema from "effect/Schema"
 import * as Field from "./Field.js"
 import * as FormBuilder from "./FormBuilder.js"
 import { recalculateDirtyFieldsForArray, recalculateDirtySubtree } from "./internal/dirty.js"
-import { getNestedValue, isPathUnderRoot, setNestedValue } from "./internal/path.js"
 import { createWeakRegistry, type WeakRegistry } from "./internal/weak-registry.js"
+import { getNestedValue, isPathUnderRoot, setNestedValue } from "./Path.js"
 import * as Validation from "./Validation.js"
 
 /**
  * Atoms for a single field.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface FieldAtoms {
@@ -27,7 +26,6 @@ export interface FieldAtoms {
 /**
  * Configuration for creating form atoms.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface FormAtomsConfig<TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = void> {
@@ -46,7 +44,6 @@ export interface FormAtomsConfig<TFields extends Field.FieldsRecord, R, A, E, Su
 /**
  * Maps field names to their type-safe Field references for setValue operations.
  *
- * @since 1.0.0
  * @category Models
  */
 export type FieldRefs<TFields extends Field.FieldsRecord> = {
@@ -60,7 +57,6 @@ export type FieldRefs<TFields extends Field.FieldsRecord> = {
 /**
  * The complete form atoms infrastructure.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface FormAtoms<TFields extends Field.FieldsRecord, R, A = void, E = never, SubmitArgs = void> {
@@ -106,7 +102,6 @@ export interface FormAtoms<TFields extends Field.FieldsRecord, R, A = void, E = 
 /**
  * Pure state operations for form manipulation.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface FormOperations<TFields extends Field.FieldsRecord> {
@@ -190,7 +185,6 @@ export interface FormOperations<TFields extends Field.FieldsRecord> {
  * })
  * ```
  *
- * @since 1.0.0
  * @category Constructors
  */
 export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = void>(

--- a/packages/form/src/FormBuilder.ts
+++ b/packages/form/src/FormBuilder.ts
@@ -1,6 +1,3 @@
-/**
- * @since 1.0.0
- */
 import type * as Registry from "@effect-atom/atom/Registry"
 import type * as Effect from "effect/Effect"
 import type * as Option from "effect/Option"
@@ -18,7 +15,6 @@ import type {
 import { isArrayFieldDef, isFieldDef } from "./Field.js"
 
 /**
- * @since 1.0.0
  * @category Models
  */
 export interface SubmittedValues<TFields extends FieldsRecord> {
@@ -29,14 +25,12 @@ export interface SubmittedValues<TFields extends FieldsRecord> {
 /**
  * Unique identifier for Field references.
  *
- * @since 1.0.0
  * @category Symbols
  * @internal
  */
 export const FieldTypeId: unique symbol = Symbol.for("@lucas-barake/effect-form/Field")
 
 /**
- * @since 1.0.0
  * @category Symbols
  * @internal
  */
@@ -45,7 +39,6 @@ export type FieldTypeId = typeof FieldTypeId
 /**
  * A field reference carrying type and path info for type-safe setValue operations.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface FieldRef<S> {
@@ -57,7 +50,6 @@ export interface FieldRef<S> {
 /**
  * Creates a field reference for type-safe setValue operations.
  *
- * @since 1.0.0
  * @category Constructors
  * @internal
  */
@@ -74,13 +66,11 @@ export const makeFieldRef = <S>(key: string): FieldRef<S> => ({
 /**
  * Unique identifier for FormBuilder instances.
  *
- * @since 1.0.0
  * @category Symbols
  */
 export const TypeId: unique symbol = Symbol.for("@lucas-barake/effect-form/Form")
 
 /**
- * @since 1.0.0
  * @category Symbols
  */
 export type TypeId = typeof TypeId
@@ -88,7 +78,6 @@ export type TypeId = typeof TypeId
 /**
  * The state of a form at runtime.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface FormState<TFields extends FieldsRecord> {
@@ -121,7 +110,6 @@ type Refinement = SyncRefinement | AsyncRefinement
  * includes a Schema for validation. The builder accumulates field definitions
  * and context requirements (`R`) from schemas that use Effect services.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface FormBuilder<TFields extends FieldsRecord, R> {
@@ -281,7 +269,6 @@ const FormBuilderProto = {
  * // Output: false
  * ```
  *
- * @since 1.0.0
  * @category Guards
  */
 export const isFormBuilder = (u: unknown): u is FormBuilder<any, any> => Predicate.hasProperty(u, TypeId)
@@ -307,7 +294,6 @@ export const isFormBuilder = (u: unknown): u is FormBuilder<any, any> => Predica
  *   .addField(PasswordField)
  * ```
  *
- * @since 1.0.0
  * @category Constructors
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -321,7 +307,6 @@ export const empty: FormBuilder<{}, never> = (() => {
 /**
  * Builds a combined Schema from a FormBuilder's field definitions.
  *
- * @since 1.0.0
  * @category Schema
  */
 export const buildSchema = <TFields extends FieldsRecord, R>(

--- a/packages/form/src/Mode.ts
+++ b/packages/form/src/Mode.ts
@@ -1,7 +1,5 @@
 /**
  * Form validation mode configuration.
- *
- * @since 1.0.0
  */
 import * as Duration from "effect/Duration"
 
@@ -17,7 +15,6 @@ import * as Duration from "effect/Duration"
  * - `{ onChange: { debounce, autoSubmit? } }`: Debounced validation, optional auto-submit
  * - `{ onBlur: { autoSubmit: true } }`: Validate on blur, auto-submit when valid
  *
- * @since 1.0.0
  * @category Models
  */
 export type FormMode =
@@ -32,7 +29,6 @@ export type FormMode =
  * Form mode without auto-submit options.
  * Used when SubmitArgs is not void, since auto-submit cannot provide custom arguments.
  *
- * @since 1.0.0
  * @category Models
  */
 export type FormModeWithoutAutoSubmit =
@@ -44,7 +40,6 @@ export type FormModeWithoutAutoSubmit =
 /**
  * Parsed form mode with resolved values.
  *
- * @since 1.0.0
  * @category Models
  */
 export interface ParsedMode {
@@ -56,7 +51,6 @@ export interface ParsedMode {
 /**
  * Parses a FormMode into a normalized ParsedMode.
  *
- * @since 1.0.0
  * @category Parsing
  */
 export const parse = (mode: FormMode = "onSubmit"): ParsedMode => {

--- a/packages/form/src/Path.ts
+++ b/packages/form/src/Path.ts
@@ -1,7 +1,5 @@
 /**
- * Internal path utilities for form field operations.
- *
- * @internal
+ * Path utilities for form field operations.
  */
 
 const BRACKET_NOTATION_REGEX = /\[(\d+)\]/g

--- a/packages/form/src/Validation.ts
+++ b/packages/form/src/Validation.ts
@@ -1,16 +1,13 @@
 /**
  * Validation utilities for form error handling.
- *
- * @since 1.0.0
  */
 import * as Option from "effect/Option"
 import * as ParseResult from "effect/ParseResult"
-import { schemaPathToFieldPath } from "./internal/path.js"
+import { schemaPathToFieldPath } from "./Path.js"
 
 /**
  * Extracts the first error message from a ParseError.
  *
- * @since 1.0.0
  * @category Error Handling
  */
 export const extractFirstError = (error: ParseResult.ParseError): Option.Option<string> => {
@@ -25,7 +22,6 @@ export const extractFirstError = (error: ParseResult.ParseError): Option.Option<
  * Routes validation errors from a ParseError to a map of field paths to error messages.
  * Used for cross-field validation where schema errors need to be displayed on specific fields.
  *
- * @since 1.0.0
  * @category Error Handling
  */
 export const routeErrors = (error: ParseResult.ParseError): Map<string, string> => {

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -1,13 +1,13 @@
 /**
  * Field definitions for type-safe forms.
- *
- * @since 1.0.0
  */
 export * as Field from "./Field.js"
 
 /**
- * @since 1.0.0
+ * Path utilities for form field operations.
  */
+export * as Path from "./Path.js"
+
 export * as FormBuilder from "./FormBuilder.js"
 
 /**
@@ -15,21 +15,15 @@ export * as FormBuilder from "./FormBuilder.js"
  *
  * This module provides the core atom infrastructure that framework adapters
  * (React, Vue, Svelte, Solid) can use to build reactive form components.
- *
- * @since 1.0.0
  */
 export * as FormAtoms from "./FormAtoms.js"
 
 /**
  * Form validation mode configuration.
- *
- * @since 1.0.0
  */
 export * as Mode from "./Mode.js"
 
 /**
  * Validation utilities for form error handling.
- *
- * @since 1.0.0
  */
 export * as Validation from "./Validation.js"

--- a/packages/form/src/internal/dirty.ts
+++ b/packages/form/src/internal/dirty.ts
@@ -5,7 +5,7 @@
  */
 import * as Equal from "effect/Equal"
 import * as Utils from "effect/Utils"
-import { getNestedValue, isPathUnderRoot } from "./path.js"
+import { getNestedValue, isPathUnderRoot } from "../Path.js"
 
 /**
  * Recalculates dirty fields for an array after mutation.

--- a/packages/form/test/Path.test.ts
+++ b/packages/form/test/Path.test.ts
@@ -1,5 +1,10 @@
+import {
+  getNestedValue,
+  isPathOrParentDirty,
+  schemaPathToFieldPath,
+  setNestedValue,
+} from "@lucas-barake/effect-form/Path"
 import { describe, expect, it } from "vitest"
-import { getNestedValue, isPathOrParentDirty, schemaPathToFieldPath, setNestedValue } from "../../src/internal/path.js"
 
 describe("path utilities", () => {
   describe("schemaPathToFieldPath", () => {


### PR DESCRIPTION
## Summary
- Promote `internal/path.ts` to public `Path.ts` module
- Fix bundler errors when consuming the library (Vite was failing with "Missing ./internal/path specifier")
- Remove `@since` JSDoc tags from entire codebase

## Changes
- `packages/form/src/Path.ts` - New public module (moved from internal)
- Updated imports in FormAtoms, Validation, dirty, FormReact
- Test file moved to `test/Path.test.ts`

## Test plan
- [x] Type check passes
- [x] All 205 tests pass
- [ ] Verify in consuming Vite app that the error is resolved