### PR TITLE
Fix public atoms crashing when subscribed before Initialize

### DIFF
--- a/.changeset/safe-atom-defaults.md
+++ b/.changeset/safe-atom-defaults.md
@@ -1,0 +1,7 @@
+---
+"@lucas-barake/effect-form": patch
+---
+
+Fix public atoms crashing when subscribed before Initialize mounts
+
+Previously, atoms like `isDirty`, `submitCount`, `hasChangedSinceSubmit` used `Option.getOrThrow` which would crash if a consumer subscribed before `<form.Initialize>` mounted. Now they return safe defaults (`false`, `0`, empty sets) when the form state is not yet initialized.


### PR DESCRIPTION
## Summary
- Fix `isDirty`, `submitCount`, `dirtyFields`, `lastSubmittedValues`, `changedSinceSubmitFields`, `hasChangedSinceSubmit` atoms crashing when subscribed before `<form.Initialize>` mounts
- Replace `Option.getOrThrow` with `Option.match` using safe defaults

## Problem
Subscribing to public atoms like `form.isDirty` in a parent component (outside `<form.Initialize>`) would crash because the state is `None` and `getOrThrow` throws.

## Fix
Each atom now returns a sensible default when state is uninitialized:
- `dirtyFieldsAtom` → empty Set
- `isDirtyAtom` → false
- `submitCountAtom` → 0
- `lastSubmittedValuesAtom` → None
- `changedSinceSubmitFieldsAtom` → empty Set
- `hasChangedSinceSubmitAtom` → false

## Test plan
- [x] Type check passes
- [x] All 205 tests pass