### PR TITLE
Add inline addField shorthand and getFieldAtom

### DIFF
--- a/.changeset/add-field-shorthand-and-get-field-atom.md
+++ b/.changeset/add-field-shorthand-and-get-field-atom.md
@@ -1,0 +1,22 @@
+---
+"@lucas-barake/effect-form": minor
+"@lucas-barake/effect-form-react": minor
+---
+
+Add inline `addField` shorthand and per-field subscriptions via `getFieldAtom`
+
+**New Features:**
+
+1. **Inline `addField` syntax** - Define fields without `Field.makeField` for one-off fields:
+   ```ts
+   FormBuilder.empty
+     .addField("email", Schema.String)
+     .addField("age", Schema.Number)
+   ```
+   Use `Field.makeField` when you need to share fields across multiple forms.
+
+2. **Per-field subscriptions** - Subscribe to individual field values without re-rendering when other fields change:
+   ```ts
+   const emailAtom = form.getFieldAtom(form.fields.email)
+   const email = useAtomValue(emailAtom) // Only re-renders when email changes
+   ```

--- a/packages/form-react/src/FormReact.tsx
+++ b/packages/form-react/src/FormReact.tsx
@@ -128,6 +128,7 @@ export type BuiltForm<
   readonly revertToLastSubmit: Atom.Writable<void, void>
   readonly setValues: Atom.Writable<void, Field.EncodedFromFields<TFields>>
   readonly setValue: <S>(field: FormBuilder.FieldRef<S>) => Atom.Writable<void, S | ((prev: S) => S)>
+  readonly getFieldAtom: <S>(field: FormBuilder.FieldRef<S>) => Atom.Atom<S>
 } & FieldComponents<TFields, CM>
 
 type FieldComponents<TFields extends Field.FieldsRecord, CM extends FieldComponentMap<TFields>> = {
@@ -570,6 +571,7 @@ export const build = <
     crossFieldErrorsAtom,
     dirtyFieldsAtom,
     fieldRefs,
+    getFieldAtom,
     getOrCreateFieldAtoms,
     getOrCreateValidationAtom,
     hasChangedSinceSubmitAtom,
@@ -670,6 +672,7 @@ export const build = <
     revertToLastSubmit: revertToLastSubmitAtom,
     setValues: setValuesAtom,
     setValue,
+    getFieldAtom,
     ...fieldComponents,
   } as BuiltForm<TFields, R, A, E, SubmitArgs, CM>
 }

--- a/packages/form/src/FormAtoms.ts
+++ b/packages/form/src/FormAtoms.ts
@@ -97,6 +97,8 @@ export interface FormAtoms<TFields extends Field.FieldsRecord, R, A = void, E = 
   readonly revertToLastSubmitAtom: Atom.Writable<void, void>
   readonly setValuesAtom: Atom.Writable<void, Field.EncodedFromFields<TFields>>
   readonly setValue: <S>(field: FormBuilder.FieldRef<S>) => Atom.Writable<void, S | ((prev: S) => S)>
+
+  readonly getFieldAtom: <S>(field: FormBuilder.FieldRef<S>) => Atom.Atom<S>
 }
 
 /**
@@ -559,6 +561,11 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
     return atom
   }
 
+  const getFieldAtom = <S>(field: FormBuilder.FieldRef<S>): Atom.Atom<S> => {
+    const { valueAtom } = getOrCreateFieldAtoms(field.key)
+    return valueAtom as Atom.Atom<S>
+  }
+
   return {
     stateAtom,
     crossFieldErrorsAtom,
@@ -582,5 +589,6 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
     revertToLastSubmitAtom,
     setValuesAtom,
     setValue,
+    getFieldAtom,
   } as FormAtoms<TFields, R, A, E, SubmitArgs>
 }

--- a/packages/form/test/Form.test.ts
+++ b/packages/form/test/Form.test.ts
@@ -19,6 +19,29 @@ describe("Form", () => {
       expect(builder.fields.email._tag).toBe("field")
     })
 
+    it("addField accepts inline key and schema", () => {
+      const builder = FormBuilder.empty
+        .addField("email", Schema.String)
+        .addField("age", Schema.Number)
+
+      expect(FormBuilder.isFormBuilder(builder)).toBe(true)
+      expect(builder.fields).toHaveProperty("email")
+      expect(builder.fields).toHaveProperty("age")
+      expect(builder.fields.email._tag).toBe("field")
+      expect(builder.fields.age._tag).toBe("field")
+    })
+
+    it("addField inline syntax builds correct schema", () => {
+      const builder = FormBuilder.empty
+        .addField("name", Schema.String)
+        .addField("age", Schema.Number)
+
+      const schema = FormBuilder.buildSchema(builder)
+      const result = Schema.decodeUnknownSync(schema)({ name: "John", age: 30 })
+
+      expect(result).toEqual({ name: "John", age: 30 })
+    })
+
     it("addArray adds an array field", () => {
       const NameField = Field.makeField("name", Schema.String)
       const AddressesField = Field.makeArrayField(

--- a/packages/form/test/FormAtoms.test.ts
+++ b/packages/form/test/FormAtoms.test.ts
@@ -1091,6 +1091,63 @@ describe("FormAtoms", () => {
     })
   })
 
+  describe("getFieldAtom", () => {
+    it("returns the value atom for a field", () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const form = makeTestForm()
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit: () => {} })
+      const registry = Registry.make()
+
+      const initialState = atoms.operations.createInitialState({
+        name: "John",
+        email: "john@test.com",
+      })
+      registry.set(atoms.stateAtom, Option.some(initialState))
+
+      const nameAtom = atoms.getFieldAtom(atoms.fieldRefs.name)
+
+      expect(registry.get(nameAtom)).toBe("John")
+    })
+
+    it("updates when field value changes", () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const form = makeTestForm()
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit: () => {} })
+      const registry = Registry.make()
+
+      let state = atoms.operations.createInitialState({
+        name: "John",
+        email: "john@test.com",
+      })
+      registry.set(atoms.stateAtom, Option.some(state))
+
+      const nameAtom = atoms.getFieldAtom(atoms.fieldRefs.name)
+      expect(registry.get(nameAtom)).toBe("John")
+
+      state = atoms.operations.setFieldValue(state, "name", "Jane")
+      registry.set(atoms.stateAtom, Option.some(state))
+
+      expect(registry.get(nameAtom)).toBe("Jane")
+    })
+
+    it("returns same atom instance for same field", () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const form = makeTestForm()
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit: () => {} })
+      const registry = Registry.make()
+
+      registry.set(
+        atoms.stateAtom,
+        Option.some(atoms.operations.createInitialState({ name: "John", email: "john@test.com" })),
+      )
+
+      const nameAtom1 = atoms.getFieldAtom(atoms.fieldRefs.name)
+      const nameAtom2 = atoms.getFieldAtom(atoms.fieldRefs.name)
+
+      expect(nameAtom1).toBe(nameAtom2)
+    })
+  })
+
   describe("submitAtom", () => {
     it("does not set lastSubmittedValues on validation failure", async () => {
       const runtime = Atom.runtime(Layer.empty)


### PR DESCRIPTION
## Summary

- **Inline `addField` syntax**: Define fields without `Field.makeField` for one-off fields
  ```ts
  FormBuilder.empty
    .addField("email", Schema.String)
    .addField("age", Schema.Number)
  ```
- **Per-field subscriptions via `getFieldAtom`**: Subscribe to individual field values without re-rendering when other fields change
  ```ts
  const emailAtom = form.getFieldAtom(form.fields.email)
  const email = useAtomValue(emailAtom)
  ```
- Updated README to use inline syntax as default, with dedicated section for reusable field patterns

## Test plan

- [x] Added tests for `addField(key, schema)` overload
- [x] Added tests for `getFieldAtom` returning correct atom and updating on changes
- [x] All 210 tests passing