### PR TITLE
Allow forField to accept FieldRef

### DIFF
--- a/.changeset/forfield-accept-fieldref.md
+++ b/.changeset/forfield-accept-fieldref.md
@@ -1,0 +1,12 @@
+---
+"@lucas-barake/effect-form-react": patch
+---
+
+`forField` now accepts both `FieldRef` (from `form.fields.x`) and `FieldDef` (from `Field.makeField`)
+
+```tsx
+// Now works with FieldRef - no need for Field.makeField
+const TextInput = FormReact.forField(form.fields.email)(({ field }) => (
+  <input value={field.value} onChange={(e) => field.onChange(e.target.value)} />
+))
+```

--- a/README.md
+++ b/README.md
@@ -561,9 +561,8 @@ interface FieldComponentProps<
 Use `FormReact.forField()` for ergonomic component definition with full type inference:
 
 ```tsx
-// Basic field component - schema type inferred from field definition
-const EmailField = Field.makeField("email", Schema.String)
-const TextInput = FormReact.forField(EmailField)(({ field }) => (
+// Using a FieldRef from the built form
+const TextInput = FormReact.forField(LoginForm.fields.email)(({ field }) => (
   <input
     value={field.value}
     onChange={(e) => field.onChange(e.target.value)}
@@ -572,7 +571,7 @@ const TextInput = FormReact.forField(EmailField)(({ field }) => (
 ))
 
 // With custom props - just specify the props type
-const TextInput = FormReact.forField(EmailField)<{ placeholder?: string }>(({ field, props }) => (
+const TextInput = FormReact.forField(LoginForm.fields.email)<{ placeholder?: string }>(({ field, props }) => (
   <input
     value={field.value}
     onChange={(e) => field.onChange(e.target.value)}
@@ -582,6 +581,10 @@ const TextInput = FormReact.forField(EmailField)<{ placeholder?: string }>(({ fi
 
 // Pass props at render time
 <LoginForm.email placeholder="Enter email" />
+
+// Also works with reusable FieldDefs
+const EmailField = Field.makeField("email", Schema.String)
+const TextInput = FormReact.forField(EmailField)(({ field }) => ...)
 ```
 
 ## License

--- a/packages/form-react/src/FormReact.tsx
+++ b/packages/form-react/src/FormReact.tsx
@@ -678,29 +678,42 @@ export const build = <
 }
 
 /**
- * A curried helper that infers the schema type from the field definition.
+ * A curried helper that infers the schema type from a field definition or field reference.
  * Provides ergonomic type inference when defining field components.
  *
  * @example
  * ```tsx
  * import { FormReact } from "@lucas-barake/effect-form-react"
  *
- * // Without extra props - schema inferred from field
+ * // Using a FieldRef from the built form
+ * const TextInput = FormReact.forField(form.fields.email)(({ field }) => (
+ *   <input value={field.value} onChange={e => field.onChange(e.target.value)} />
+ * ))
+ *
+ * // Using a FieldDef (for reusable fields)
+ * const EmailField = Field.makeField("email", Schema.String)
  * const TextInput = FormReact.forField(EmailField)(({ field }) => (
  *   <input value={field.value} onChange={e => field.onChange(e.target.value)} />
  * ))
  *
  * // With extra props - just specify the props type
- * const TextInput = FormReact.forField(EmailField)<{ placeholder?: string }>(({ field, props }) => (
+ * const TextInput = FormReact.forField(form.fields.email)<{ placeholder?: string }>(({ field, props }) => (
  *   <input value={field.value} placeholder={props.placeholder} ... />
  * ))
  * ```
  *
  * @category Constructors
  */
-export const forField = <K extends string, S extends Schema.Schema.Any>(
-  _field: Field.FieldDef<K, S>,
-) =>
-<P extends Record<string, unknown> = Record<string, never>>(
-  component: React.FC<FieldComponentProps<S, P>>,
-): React.FC<FieldComponentProps<S, P>> => component
+export const forField: {
+  <S>(
+    _field: FormBuilder.FieldRef<S>,
+  ): <P extends Record<string, unknown> = Record<string, never>>(
+    component: React.FC<FieldComponentProps<Schema.Schema<S, S, never>, P>>,
+  ) => React.FC<FieldComponentProps<Schema.Schema<S, S, never>, P>>
+
+  <K extends string, S extends Schema.Schema.Any>(
+    _field: Field.FieldDef<K, S>,
+  ): <P extends Record<string, unknown> = Record<string, never>>(
+    component: React.FC<FieldComponentProps<S, P>>,
+  ) => React.FC<FieldComponentProps<S, P>>
+} = (_field: unknown) => (component: unknown) => component as any


### PR DESCRIPTION
## Summary

`forField` now accepts both:
- `FieldRef` (from `form.fields.x`) 
- `FieldDef` (from `Field.makeField`)

This improves DX when using inline `addField` syntax - you no longer need `Field.makeField` just to get type inference with `forField`.

```tsx
// Before: required Field.makeField
const EmailField = Field.makeField("email", Schema.String)
const TextInput = FormReact.forField(EmailField)(...)

// Now: works directly with FieldRef
const TextInput = FormReact.forField(form.fields.email)(...)
```

## Test plan

- [x] Type checks pass
- [x] All 210 tests passing