### PR TITLE
Change makeField to curried API for better type inference

### DIFF
--- a/.changeset/curried-makefield.md
+++ b/.changeset/curried-makefield.md
@@ -1,0 +1,35 @@
+---
+"@lucas-barake/effect-form-react": major
+---
+
+**BREAKING:** Changed `makeField` to use a curried API for better type inference.
+
+Previously, users had to explicitly type `FieldComponentProps` including the schema type:
+
+```tsx
+const NameInput = FormReact.makeField({
+  key: "name",
+  schema: Schema.String,
+  component: ({ field, props }: FormReact.FieldComponentProps<typeof Schema.String, { disabled: boolean }>) => ...
+})
+```
+
+Now, `makeField` is curried - the schema type is captured first, so you only need to specify extra props:
+
+```tsx
+// No extra props
+const NameInput = FormReact.makeField({
+  key: "name",
+  schema: Schema.String,
+})(({ field }) => ...)
+
+// With extra props - only specify the props type
+const NameInput = FormReact.makeField({
+  key: "name",
+  schema: Schema.String,
+})<{ disabled: boolean }>(({ field, props }) => ...)
+```
+
+Migration: Move `component` from inside the config object to a second function call.
+
+Additionally, `makeField` now automatically sets the component's `displayName` based on the key (e.g., `"name"` → `"NameField"`), improving React DevTools debugging experience.

--- a/README.md
+++ b/README.md
@@ -521,18 +521,29 @@ Use `FormReact.makeField` to bundle a field definition with its component in one
 import { FormBuilder, FormReact } from "@lucas-barake/effect-form-react"
 import * as Schema from "effect/Schema"
 
-// Define field + component together
+// Define field + component together (curried API)
 const NameInput = FormReact.makeField({
   key: "name",
   schema: Schema.String.pipe(Schema.nonEmptyString()),
-  component: ({ field }) => (
-    <input
-      value={field.value}
-      onChange={(e) => field.onChange(e.target.value)}
-      onBlur={field.onBlur}
-    />
-  ),
-})
+})(({ field }) => (
+  <input
+    value={field.value}
+    onChange={(e) => field.onChange(e.target.value)}
+    onBlur={field.onBlur}
+  />
+))
+
+// With extra props - specify only the props type
+const EmailInput = FormReact.makeField({
+  key: "email",
+  schema: Schema.String,
+})<{ placeholder: string }>(({ field, props }) => (
+  <input
+    value={field.value}
+    onChange={(e) => field.onChange(e.target.value)}
+    placeholder={props.placeholder}
+  />
+))
 
 // Use .field for form builder
 const formBuilder = FormBuilder.empty.addField(NameInput.field)
@@ -552,8 +563,7 @@ This reduces boilerplate when you need reusable field + component combos across 
 export const NameInput = FormReact.makeField({
   key: "name",
   schema: Schema.String.pipe(Schema.nonEmptyString()),
-  component: ({ field }) => <TextInput field={field} />,
-})
+})(({ field }) => <TextInput field={field} />)
 
 // forms/user-form.tsx
 import { NameInput } from "../fields/name-input"


### PR DESCRIPTION
## Summary

- Changes `makeField` from all-in-one config to curried API matching `forField` pattern
- Schema type is captured first, so users only need to specify extra props type (if any)
- Significantly improves DX by eliminating verbose `FieldComponentProps` type annotations

## Before/After

```tsx
// Before (verbose - had to type full FieldComponentProps)
const NameInput = FormReact.makeField({
  key: "name",
  schema: Schema.String,
  component: ({ field, props }: FormReact.FieldComponentProps<typeof Schema.String, { disabled: boolean }>) => ...
})

// After (clean - only type the props you add)
const NameInput = FormReact.makeField({
  key: "name",
  schema: Schema.String,
})<{ disabled: boolean }>(({ field, props }) => ...)

// No extra props - just omit the type parameter
const NameInput = FormReact.makeField({
  key: "name",
  schema: Schema.String,
})(({ field }) => ...)
```

## Breaking Change

Migration is straightforward: move `component` from inside the config object to a second function call.

## Test plan

- [x] Type checking passes
- [ ] Manual testing with real usage