### PR TITLE
Fix changeset to minor (pre-v1)

### DIFF
--- a/.changeset/curried-makefield.md
+++ b/.changeset/curried-makefield.md
@@ -1,5 +1,5 @@
 ---
-"@lucas-barake/effect-form-react": major
+"@lucas-barake/effect-form-react": minor
 ---
 
 **BREAKING:** Changed `makeField` to use a curried API for better type inference.


### PR DESCRIPTION
## Summary

- Changes changeset from `major` to `minor` since we're still pre-v1

The breaking change should still be documented but shouldn't trigger a v1.0.0 release.