### PR TITLE
Rename FormReact.build to FormReact.make

### DIFF
--- a/.changeset/rename-build-to-make.md
+++ b/.changeset/rename-build-to-make.md
@@ -1,0 +1,5 @@
+---
+"@lucas-barake/effect-form-react": minor
+---
+
+Rename `FormReact.build` to `FormReact.make` to follow Effect naming conventions

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const loginFormBuilder = FormBuilder.empty
   .addField("email", Schema.String.pipe(Schema.nonEmptyString()))
   .addField("password", Schema.String.pipe(Schema.minLength(8)))
 
-const LoginForm = FormReact.build(loginFormBuilder, {
+const loginForm = FormReact.make(loginFormBuilder, {
   runtime,
   fields: {
     email: ({ field }) => (
@@ -55,9 +55,9 @@ const LoginForm = FormReact.build(loginFormBuilder, {
 
 // Subscribe to atoms anywhere in the tree
 function SubmitButton() {
-  const isDirty = useAtomValue(LoginForm.isDirty)
-  const submitResult = useAtomValue(LoginForm.submit)
-  const submit = useAtomSet(LoginForm.submit)
+  const isDirty = useAtomValue(loginForm.isDirty)
+  const submitResult = useAtomValue(loginForm.submit)
+  const submit = useAtomSet(loginForm.submit)
   return (
     <button onClick={() => submit()} disabled={!isDirty || submitResult.waiting}>
       Login
@@ -67,11 +67,11 @@ function SubmitButton() {
 
 function LoginPage() {
   return (
-    <LoginForm.Initialize defaultValues={{ email: "", password: "" }}>
-      <LoginForm.email />
-      <LoginForm.password />
+    <loginForm.Initialize defaultValues={{ email: "", password: "" }}>
+      <loginForm.email />
+      <loginForm.password />
       <SubmitButton />
-    </LoginForm.Initialize>
+    </loginForm.Initialize>
   )
 }
 ```
@@ -85,7 +85,7 @@ const orderFormBuilder = FormBuilder.empty
   .addField("title", Schema.String)
   .addField(Field.makeArrayField("items", Schema.Struct({ name: Schema.String })))
 
-const OrderForm = FormReact.build(orderFormBuilder, {
+const orderForm = FormReact.make(orderFormBuilder, {
   runtime,
   fields: {
     title: TitleInput,
@@ -96,22 +96,22 @@ const OrderForm = FormReact.build(orderFormBuilder, {
 
 function OrderPage() {
   return (
-    <OrderForm.Initialize defaultValues={{ title: "", items: [] }}>
-      <OrderForm.title />
-      <OrderForm.items>
+    <orderForm.Initialize defaultValues={{ title: "", items: [] }}>
+      <orderForm.title />
+      <orderForm.items>
         {({ items, append, remove, swap, move }) => (
           <>
             {items.map((_, index) => (
-              <OrderForm.items.Item key={index} index={index}>
+              <orderForm.items.Item key={index} index={index}>
                 {({ remove }) => (
                   <div>
-                    <OrderForm.items.name />
+                    <orderForm.items.name />
                     <button type="button" onClick={remove}>
                       Remove
                     </button>
                   </div>
                 )}
-              </OrderForm.items.Item>
+              </orderForm.items.Item>
             ))}
             <button type="button" onClick={() => append()}>
               Add Item
@@ -124,8 +124,8 @@ function OrderPage() {
             </button>
           </>
         )}
-      </OrderForm.items>
-    </OrderForm.Initialize>
+      </orderForm.items>
+    </orderForm.Initialize>
   )
 }
 ```
@@ -133,9 +133,9 @@ function OrderPage() {
 ## 3. Validation Modes
 
 ```tsx
-FormReact.build(form, { runtime, fields, mode: "onSubmit", onSubmit })
-FormReact.build(form, { runtime, fields, mode: "onBlur", onSubmit })
-FormReact.build(form, { runtime, fields, mode: "onChange", onSubmit })
+FormReact.make(formBuilder, { runtime, fields, mode: "onSubmit", onSubmit })
+FormReact.make(formBuilder, { runtime, fields, mode: "onBlur", onSubmit })
+FormReact.make(formBuilder, { runtime, fields, mode: "onChange", onSubmit })
 ```
 
 ## 4. Cross-Field Validation (Sync Refinements)
@@ -199,7 +199,7 @@ const signupFormBuilder = FormBuilder.empty
     }),
   )
 
-const SignupForm = FormReact.build(signupFormBuilder, {
+const signupForm = FormReact.make(signupFormBuilder, {
   runtime,
   fields: { username: UsernameInput },
   onSubmit: (_, { decoded }) => Effect.log(`Signup: ${decoded.username}`),
@@ -212,9 +212,9 @@ Operations are AtomResultFns - use `useAtomSet` to call them:
 
 ```tsx
 function FormControls() {
-  const setEmail = useAtomSet(LoginForm.setValue(LoginForm.fields.email))
-  const setPassword = useAtomSet(LoginForm.setValue(LoginForm.fields.password))
-  const setAllValues = useAtomSet(LoginForm.setValues)
+  const setEmail = useAtomSet(loginForm.setValue(loginForm.fields.email))
+  const setPassword = useAtomSet(loginForm.setValue(loginForm.fields.password))
+  const setAllValues = useAtomSet(loginForm.setValues)
 
   return (
     <>
@@ -237,14 +237,14 @@ function FormControls() {
 ## 8. Auto-Submit Mode
 
 ```tsx
-FormReact.build(form, {
+FormReact.make(formBuilder, {
   runtime,
   fields,
   mode: { onChange: { debounce: "300 millis", autoSubmit: true } },
   onSubmit,
 })
 
-FormReact.build(form, {
+FormReact.make(formBuilder, {
   runtime,
   fields,
   mode: { onBlur: { autoSubmit: true } },
@@ -255,7 +255,7 @@ FormReact.build(form, {
 ## 9. Debounced Validation
 
 ```tsx
-FormReact.build(form, {
+FormReact.make(formBuilder, {
   runtime,
   fields,
   mode: { onChange: { debounce: "300 millis" } },
@@ -267,8 +267,8 @@ FormReact.build(form, {
 
 ```tsx
 function FormStatus() {
-  const isDirty = useAtomValue(LoginForm.isDirty)
-  const reset = useAtomSet(LoginForm.reset)
+  const isDirty = useAtomValue(loginForm.isDirty)
+  const reset = useAtomSet(loginForm.reset)
 
   return (
     <>
@@ -300,9 +300,9 @@ Track whether form values differ from the last submitted state. Useful for "reve
 
 ```tsx
 function FormStatus() {
-  const hasChangedSinceSubmit = useAtomValue(LoginForm.hasChangedSinceSubmit)
-  const lastSubmittedValues = useAtomValue(LoginForm.lastSubmittedValues)
-  const revertToLastSubmit = useAtomSet(LoginForm.revertToLastSubmit)
+  const hasChangedSinceSubmit = useAtomValue(loginForm.hasChangedSinceSubmit)
+  const lastSubmittedValues = useAtomValue(loginForm.lastSubmittedValues)
+  const revertToLastSubmit = useAtomSet(loginForm.revertToLastSubmit)
 
   return (
     <>
@@ -340,9 +340,9 @@ import { useAtomValue, useAtomSubscribe } from "@effect-atom/atom-react"
 
 // Read atoms directly
 function FormDebug() {
-  const isDirty = useAtomValue(LoginForm.isDirty)
-  const submitCount = useAtomValue(LoginForm.submitCount)
-  const submitResult = useAtomValue(LoginForm.submit)
+  const isDirty = useAtomValue(loginForm.isDirty)
+  const submitCount = useAtomValue(loginForm.submitCount)
+  const submitResult = useAtomValue(loginForm.submit)
 
   return (
     <pre>
@@ -356,7 +356,7 @@ function FormDebug() {
 // Subscribe to changes with side effects
 function FormSideEffects() {
   useAtomSubscribe(
-    LoginForm.isDirty,
+    loginForm.isDirty,
     (isDirty) => {
       console.log("Dirty state changed:", isDirty)
     },
@@ -375,7 +375,7 @@ The atom returns `Option<T>` - `None` before initialization, `Some(value)` after
 ```tsx
 function EmailDisplay() {
   // Only re-renders when email changes, not when password changes
-  const emailAtom = LoginForm.getFieldAtom(LoginForm.fields.email)
+  const emailAtom = loginForm.getFieldAtom(loginForm.fields.email)
   const emailOption = useAtomValue(emailAtom)
 
   // Safe to use outside Initialize - returns None before form mounts
@@ -387,7 +387,7 @@ function EmailDisplay() {
 
 // Inside Initialize where state is guaranteed
 function PasswordStrength() {
-  const passwordAtom = LoginForm.getFieldAtom(LoginForm.fields.password)
+  const passwordAtom = loginForm.getFieldAtom(loginForm.fields.password)
   const passwordOption = useAtomValue(passwordAtom)
 
   // Can safely getOrThrow inside Initialize
@@ -417,7 +417,7 @@ const TextInput: React.FC<
 import * as Result from "@effect-atom/atom/Result"
 
 function SubmitStatus() {
-  const submitResult = useAtomValue(LoginForm.submit)
+  const submitResult = useAtomValue(loginForm.submit)
 
   if (submitResult.waiting) return <span>Submitting...</span>
   if (Result.isSuccess(submitResult)) return <span>Success!</span>
@@ -428,7 +428,7 @@ function SubmitStatus() {
 // For side effects after submit (navigation, close dialog, etc.):
 function FormWithSideEffects({ onClose }: { onClose: () => void }) {
   useAtomSubscribe(
-    LoginForm.submit,
+    loginForm.submit,
     (result) => {
       if (Result.isSuccess(result)) {
         onClose()
@@ -437,7 +437,7 @@ function FormWithSideEffects({ onClose }: { onClose: () => void }) {
     { immediate: false },
   )
 
-  return <LoginForm.Initialize defaultValues={{ email: "", password: "" }}>...</LoginForm.Initialize>
+  return <loginForm.Initialize defaultValues={{ email: "", password: "" }}>...</loginForm.Initialize>
 }
 ```
 
@@ -447,7 +447,7 @@ Pass custom arguments to `onSubmit` by annotating the first parameter:
 
 ```tsx
 // Define form with custom submit args
-const ContactForm = FormReact.build(formBuilder, {
+const contactForm = FormReact.make(contactFormBuilder, {
   runtime,
   fields: { email: TextInput, message: TextInput },
   onSubmit: (args: { source: string }, { decoded, encoded, get }) =>
@@ -456,7 +456,7 @@ const ContactForm = FormReact.build(formBuilder, {
 
 // Pass args when submitting
 function SubmitButton({ source }: { source: string }) {
-  const submit = useAtomSet(ContactForm.submit)
+  const submit = useAtomSet(contactForm.submit)
   return <button onClick={() => submit({ source })}>Send</button>
 }
 ```
@@ -548,8 +548,8 @@ const EmailInput = FormReact.makeField({
 // Use .field for form builder
 const formBuilder = FormBuilder.empty.addField(NameInput.field)
 
-// Use the bundle directly in build()
-const Form = FormReact.build(formBuilder, {
+// Use the bundle directly in make()
+const form = FormReact.make(formBuilder, {
   runtime,
   fields: { name: NameInput },
   onSubmit: (_, { decoded }) => Effect.log(decoded.name),
@@ -568,8 +568,8 @@ export const NameInput = FormReact.makeField({
 // forms/user-form.tsx
 import { NameInput } from "../fields/name-input"
 
-const form = FormBuilder.empty.addField(NameInput.field).addField("email", Schema.String)
-const UserForm = FormReact.build(form, {
+const userFormBuilder = FormBuilder.empty.addField(NameInput.field).addField("email", Schema.String)
+const userForm = FormReact.make(userFormBuilder, {
   runtime,
   fields: { name: NameInput, email: EmailComponent },
   onSubmit: ...,
@@ -578,8 +578,8 @@ const UserForm = FormReact.build(form, {
 // forms/profile-form.tsx
 import { NameInput } from "../fields/name-input"
 
-const form = FormBuilder.empty.addField(NameInput.field).addField("bio", Schema.String)
-const ProfileForm = FormReact.build(form, {
+const profileFormBuilder = FormBuilder.empty.addField(NameInput.field).addField("bio", Schema.String)
+const profileForm = FormReact.make(profileFormBuilder, {
   runtime,
   fields: { name: NameInput, bio: BioComponent },
   onSubmit: ...,

--- a/packages/form-react/src/FormReact.tsx
+++ b/packages/form-react/src/FormReact.tsx
@@ -130,7 +130,6 @@ export type BuiltForm<
   SubmitArgs = void,
   CM extends FieldComponentMap<TFields> = FieldComponentMap<TFields>,
 > = {
-  // Atoms for fine-grained subscriptions (use with useAtomValue)
   readonly values: Atom.Atom<Option.Option<Field.EncodedFromFields<TFields>>>
   readonly isDirty: Atom.Atom<boolean>
   readonly hasChangedSinceSubmit: Atom.Atom<boolean>
@@ -436,7 +435,6 @@ const makeArrayFieldComponent = <S extends Schema.Schema.Any>(
     ...itemFieldComponents,
   }
 
-  // Proxy enables <Form.items.Item> and <Form.items.name> syntax
   return new Proxy(ArrayWrapper, {
     get(target, prop) {
       if (prop in properties) {
@@ -509,7 +507,7 @@ const makeFieldComponents = <
 }
 
 /**
- * Builds a React form from a FormBuilder.
+ * Creates a React form from a FormBuilder.
  *
  * @example
  * ```tsx
@@ -522,11 +520,11 @@ const makeFieldComponents = <
  *
  * const runtime = Atom.runtime(Layer.empty)
  *
- * const loginForm = FormBuilder.empty
+ * const loginFormBuilder = FormBuilder.empty
  *   .addField("email", Schema.String)
  *   .addField("password", Schema.String)
  *
- * const form = FormReact.build(loginForm, {
+ * const loginForm = FormReact.make(loginFormBuilder, {
  *   runtime,
  *   fields: { email: TextInput, password: PasswordInput },
  *   onSubmit: (values) => Effect.log(`Login: ${values.email}`),
@@ -534,9 +532,9 @@ const makeFieldComponents = <
  *
  * // Subscribe to atoms anywhere in the tree
  * function SubmitButton() {
- *   const isDirty = useAtomValue(form.isDirty)
- *   const submit = useAtomValue(form.submit)
- *   const callSubmit = useAtomSet(form.submit)
+ *   const isDirty = useAtomValue(loginForm.isDirty)
+ *   const submit = useAtomValue(loginForm.submit)
+ *   const callSubmit = useAtomSet(loginForm.submit)
  *   return (
  *     <button onClick={() => callSubmit()} disabled={!isDirty || submit.waiting}>
  *       {submit.waiting ? "Validating..." : "Login"}
@@ -544,20 +542,20 @@ const makeFieldComponents = <
  *   )
  * }
  *
- * function LoginDialog({ onClose }) {
+ * function LoginPage() {
  *   return (
- *     <form.Initialize defaultValues={{ email: "", password: "" }}>
- *       <form.email />
- *       <form.password />
+ *     <loginForm.Initialize defaultValues={{ email: "", password: "" }}>
+ *       <loginForm.email />
+ *       <loginForm.password />
  *       <SubmitButton />
- *     </form.Initialize>
+ *     </loginForm.Initialize>
  *   )
  * }
  * ```
  *
  * @category Constructors
  */
-export const build = <
+export const make = <
   TFields extends Field.FieldsRecord,
   R,
   A,
@@ -767,10 +765,10 @@ export const forField = <K extends string, S extends Schema.Schema.Any>(
  * ))
  *
  * // Use in form builder
- * const form = FormBuilder.empty.addField(NameInput.field)
+ * const formBuilder = FormBuilder.empty.addField(NameInput.field)
  *
- * // Use in build()
- * const Form = FormReact.build(form, {
+ * // Use in make()
+ * const form = FormReact.make(formBuilder, {
  *   runtime,
  *   fields: { name: NameInput },
  *   onSubmit: (_, { decoded }) => Effect.log(decoded.name),
@@ -788,7 +786,6 @@ export const makeField = <K extends string, S extends Schema.Schema.Any>(options
   const field = Field.makeField(options.key, options.schema)
   return (component) => {
     // DX: Auto-generate a readable component name for DevTools
-    // e.g., key "email" -> "<EmailField />"
     if (!component.displayName) {
       const displayName = `${options.key.charAt(0).toUpperCase()}${options.key.slice(1)}Field`
       // Cast to 'any' because strict TS marks function names as readonly,

--- a/packages/form-react/test/FormReact.test.tsx
+++ b/packages/form-react/test/FormReact.test.tsx
@@ -36,7 +36,7 @@ const makeSubmitButton = <A,>(submitAtom: Atom.AtomResultFn<A, unknown, unknown>
   return SubmitButton
 }
 
-describe("FormReact.build", () => {
+describe("FormReact.make", () => {
   describe("Initialize Component", () => {
     it("initializes with default values", () => {
       const NameField = Field.makeField("name", Schema.String)
@@ -44,7 +44,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
@@ -69,7 +69,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
@@ -96,7 +96,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         mode: "onBlur",
@@ -126,7 +126,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
@@ -159,7 +159,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
@@ -195,7 +195,7 @@ describe("FormReact.build", () => {
       const formBuilder = FormBuilder.empty.addField(NameField)
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { name: TextInput },
         onSubmit: (_: void, { decoded }) => submitHandler(decoded),
@@ -248,7 +248,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: {
           firstName: FirstNameInput,
@@ -302,7 +302,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: {
           title: TitleInput,
@@ -361,7 +361,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { items: { name: ItemNameInput } },
         onSubmit,
@@ -424,7 +424,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { items: { name: ItemNameInput } },
         onSubmit,
@@ -484,7 +484,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { items: { name: ItemNameInput } },
         onSubmit,
@@ -540,7 +540,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { items: { name: ItemNameInput } },
         onSubmit,
@@ -595,7 +595,7 @@ describe("FormReact.build", () => {
       const formBuilder = FormBuilder.empty.addField(EmailField)
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { email: TextInput },
         onSubmit: (_: void, { decoded }) => submitHandler(decoded),
@@ -643,7 +643,7 @@ describe("FormReact.build", () => {
       const onSubmit = () => {}
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { asyncField: ValidatingInput },
         mode: "onBlur",
@@ -714,7 +714,7 @@ describe("FormReact.build", () => {
       const onSubmit = () => {}
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: {
           password: PasswordInput,
@@ -773,7 +773,7 @@ describe("FormReact.build", () => {
       const onSubmit = () => {}
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { username: UsernameInput },
         onSubmit,
@@ -840,7 +840,7 @@ describe("FormReact.build", () => {
       const onSubmit = () => {}
 
       const runtime = Atom.runtime(UsernameValidatorLive)
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { username: UsernameInput },
         onSubmit,
@@ -857,7 +857,6 @@ describe("FormReact.build", () => {
 
       await user.click(screen.getByTestId("submit"))
 
-      // Validation should work using the service
       await waitFor(() => {
         expect(screen.getByTestId("username-error")).toHaveTextContent("Username is already taken")
       })
@@ -908,7 +907,7 @@ describe("FormReact.build", () => {
       const onSubmit = () => {}
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { fieldA: FieldAInput, fieldB: FieldBInput },
         onSubmit,
@@ -987,7 +986,7 @@ describe("FormReact.build", () => {
       const onSubmit = () => {}
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { password: PasswordInput, confirm: ConfirmInput },
         onSubmit,
@@ -1043,7 +1042,7 @@ describe("FormReact.build", () => {
       const onSubmit = () => {}
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { items: { name: ItemNameInput } },
         onSubmit,
@@ -1088,7 +1087,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         mode: "onChange",
@@ -1121,7 +1120,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         mode: "onSubmit",
@@ -1152,7 +1151,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         mode: "onSubmit",
@@ -1188,7 +1187,7 @@ describe("FormReact.build", () => {
       const onSubmit = () => Effect.fail(new Error("Submission failed"))
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { name: TextInput },
         onSubmit,
@@ -1232,7 +1231,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
@@ -1271,7 +1270,7 @@ describe("FormReact.build", () => {
       const onSubmit = () => Effect.void.pipe(Effect.delay("50 millis"))
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { name: TextInput },
         onSubmit,
@@ -1318,7 +1317,7 @@ describe("FormReact.build", () => {
       const onSubmit = () => {}
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { name: TextInput },
         onSubmit,
@@ -1359,7 +1358,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
@@ -1399,7 +1398,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
@@ -1434,7 +1433,6 @@ describe("FormReact.build", () => {
       // Rerender with new defaultValues - form does NOT reinitialize
       rerender(<FormWrapper defaultName="new-initial" />)
 
-      // Values preserved from previous render
       expect(screen.getByTestId("text-input")).toHaveValue("modified")
       expect(isDirty).toBe(true)
     })
@@ -1447,7 +1445,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
@@ -1496,7 +1494,7 @@ describe("FormReact.build", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
@@ -1539,7 +1537,7 @@ describe("FormReact.build", () => {
       const onSubmit = () => {}
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { name: TextInput },
         onSubmit,
@@ -1585,7 +1583,7 @@ describe("FormReact.build", () => {
       const onSubmit = () => {}
 
       const runtime = createRuntime()
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime,
         fields: { name: TextInput },
         onSubmit,

--- a/packages/form-react/test/internal/debounce-auto-submit.test.tsx
+++ b/packages/form-react/test/internal/debounce-auto-submit.test.tsx
@@ -55,7 +55,7 @@ describe("Debounce and Auto-Submit", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         mode: { onChange: { debounce: "300 millis" } },
@@ -94,7 +94,7 @@ describe("Debounce and Auto-Submit", () => {
 
       const formBuilder = FormBuilder.empty.addField(NameField)
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         mode: { onChange: { debounce: "100 millis", autoSubmit: true } },
@@ -131,7 +131,7 @@ describe("Debounce and Auto-Submit", () => {
         .addField(NameField)
         .addField(AgeField)
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: NameInput, age: AgeInput },
         mode: { onChange: { debounce: "100 millis", autoSubmit: true } },
@@ -171,7 +171,7 @@ describe("Debounce and Auto-Submit", () => {
 
       const formBuilder = FormBuilder.empty.addField(NameFieldMinLength)
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         mode: { onChange: { debounce: "50 millis", autoSubmit: true } },
@@ -211,7 +211,7 @@ describe("Debounce and Auto-Submit", () => {
 
       const formBuilder = FormBuilder.empty.addField(NameField)
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         mode: { onChange: { debounce: "100 millis", autoSubmit: true } },
@@ -243,7 +243,7 @@ describe("Debounce and Auto-Submit", () => {
 
       const formBuilder = FormBuilder.empty.addField(NameField)
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         mode: { onBlur: { autoSubmit: true } },
@@ -281,7 +281,7 @@ describe("Debounce and Auto-Submit", () => {
 
       const onSubmit = () => {}
 
-      const form = FormReact.build(formBuilder, {
+      const form = FormReact.make(formBuilder, {
         runtime: createRuntime(),
         fields: { name: TextInput },
         mode: "onChange",

--- a/packages/form/test/FormAtoms.test.ts
+++ b/packages/form/test/FormAtoms.test.ts
@@ -976,7 +976,6 @@ describe("FormAtoms", () => {
       registry.mount(atoms.revertToLastSubmitAtom)
       registry.set(atoms.revertToLastSubmitAtom, undefined)
 
-      // Should go back to "Jane" (last submitted)
       const revertedState = registry.get(atoms.stateAtom).pipe(Option.getOrThrow)
       expect(revertedState.values.name).toBe("Jane")
       expect(registry.get(atoms.crossFieldErrorsAtom).size).toBe(0)
@@ -1082,7 +1081,6 @@ describe("FormAtoms", () => {
       registry.mount(setItemsAtom)
       registry.set(setItemsAtom, [{ name: "Updated Item" }])
 
-      // items and nested paths should be cleared, title should remain
       const errors = registry.get(atoms.crossFieldErrorsAtom)
       expect(errors.has("items")).toBe(false)
       expect(errors.has("items[0]")).toBe(false)

--- a/packages/form/test/Validation.test.ts
+++ b/packages/form/test/Validation.test.ts
@@ -107,7 +107,6 @@ describe("Validation", () => {
       }
 
       const errors = routeErrors(result.left)
-      // Only first field error captured (schema short-circuits)
       expect(errors.size).toBe(1)
       expect(errors.has("name")).toBe(true)
     })
@@ -166,7 +165,6 @@ describe("Validation", () => {
       }
 
       const errors = routeErrors(result.left)
-      // Only first array item error captured (schema short-circuits)
       expect(errors.size).toBe(1)
       expect(errors.has("items[0].name")).toBe(true)
     })


### PR DESCRIPTION
## Summary
- Renames `FormReact.build` to `FormReact.make` to follow Effect naming conventions (`make` for constructors with config objects)
- Updates README examples with proper naming conventions:
  - `loginFormBuilder` for FormBuilder instances
  - `loginForm` for built form instances (camelCase to avoid conflicts with React component names)
- Updates all test files and JSDoc examples

## Breaking Change
`FormReact.build` → `FormReact.make`

## Test plan
- [x] All 212 tests pass
- [x] Type check passes