### PR TITLE
Make runtime optional in FormReact.make for forms without service requirements

### DIFF
--- a/.changeset/optional-runtime.md
+++ b/.changeset/optional-runtime.md
@@ -1,0 +1,8 @@
+---
+"@lucas-barake/effect-form-react": minor
+---
+
+Make `runtime` optional in `FormReact.make()` for forms without service requirements
+
+When `R = never` (no services needed), runtime can be omitted and defaults to `Atom.runtime(Layer.empty)`.
+Forms with service requirements (via `refineEffect` or `Schema.filterEffect`) still require an explicit runtime.

--- a/README.md
+++ b/README.md
@@ -13,20 +13,15 @@ pnpm add @lucas-barake/effect-form-react
 ```tsx
 import { FormBuilder, FormReact } from "@lucas-barake/effect-form-react"
 import { useAtomValue, useAtomSet } from "@effect-atom/atom-react"
-import * as Atom from "@effect-atom/atom/Atom"
 import * as Schema from "effect/Schema"
 import * as Effect from "effect/Effect"
 import * as Option from "effect/Option"
-import * as Layer from "effect/Layer"
-
-const runtime = Atom.runtime(Layer.empty)
 
 const loginFormBuilder = FormBuilder.empty
   .addField("email", Schema.String.pipe(Schema.nonEmptyString()))
   .addField("password", Schema.String.pipe(Schema.minLength(8)))
 
 const loginForm = FormReact.make(loginFormBuilder, {
-  runtime,
   fields: {
     email: ({ field }) => (
       <div>
@@ -133,9 +128,9 @@ function OrderPage() {
 ## 3. Validation Modes
 
 ```tsx
-FormReact.make(formBuilder, { runtime, fields, mode: "onSubmit", onSubmit })
-FormReact.make(formBuilder, { runtime, fields, mode: "onBlur", onSubmit })
-FormReact.make(formBuilder, { runtime, fields, mode: "onChange", onSubmit })
+FormReact.make(formBuilder, { fields, mode: "onSubmit", onSubmit })
+FormReact.make(formBuilder, { fields, mode: "onBlur", onSubmit })
+FormReact.make(formBuilder, { fields, mode: "onChange", onSubmit })
 ```
 
 ## 4. Cross-Field Validation (Sync Refinements)
@@ -238,14 +233,12 @@ function FormControls() {
 
 ```tsx
 FormReact.make(formBuilder, {
-  runtime,
   fields,
   mode: { onChange: { debounce: "300 millis", autoSubmit: true } },
   onSubmit,
 })
 
 FormReact.make(formBuilder, {
-  runtime,
   fields,
   mode: { onBlur: { autoSubmit: true } },
   onSubmit,
@@ -256,7 +249,6 @@ FormReact.make(formBuilder, {
 
 ```tsx
 FormReact.make(formBuilder, {
-  runtime,
   fields,
   mode: { onChange: { debounce: "300 millis" } },
   onSubmit,

--- a/packages/form-react/test/FormReact.test.tsx
+++ b/packages/form-react/test/FormReact.test.tsx
@@ -13,8 +13,6 @@ import * as Schema from "effect/Schema"
 import * as React from "react"
 import { describe, expect, it, vi } from "vitest"
 
-const createRuntime = () => Atom.runtime(Layer.empty)
-
 const TextInput: React.FC<FormReact.FieldComponentProps<typeof Schema.String>> = ({ field }) => (
   <div>
     <input
@@ -45,7 +43,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
       })
@@ -70,7 +67,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
       })
@@ -97,7 +93,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         mode: "onBlur",
         onSubmit,
@@ -127,7 +122,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
       })
@@ -160,7 +154,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
       })
@@ -194,9 +187,7 @@ describe("FormReact.make", () => {
       const NameField = Field.makeField("name", Schema.String)
       const formBuilder = FormBuilder.empty.addField(NameField)
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: { name: TextInput },
         onSubmit: (_: void, { decoded }) => submitHandler(decoded),
       })
@@ -249,7 +240,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: {
           firstName: FirstNameInput,
           lastName: LastNameInput,
@@ -303,7 +293,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: {
           title: TitleInput,
           items: { name: ItemNameInput },
@@ -362,7 +351,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { items: { name: ItemNameInput } },
         onSubmit,
       })
@@ -425,7 +413,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { items: { name: ItemNameInput } },
         onSubmit,
       })
@@ -485,7 +472,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { items: { name: ItemNameInput } },
         onSubmit,
       })
@@ -541,7 +527,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { items: { name: ItemNameInput } },
         onSubmit,
       })
@@ -594,9 +579,7 @@ describe("FormReact.make", () => {
       const EmailField = Field.makeField("email", AsyncEmail)
       const formBuilder = FormBuilder.empty.addField(EmailField)
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: { email: TextInput },
         onSubmit: (_: void, { decoded }) => submitHandler(decoded),
       })
@@ -642,9 +625,7 @@ describe("FormReact.make", () => {
 
       const onSubmit = () => {}
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: { asyncField: ValidatingInput },
         mode: "onBlur",
         onSubmit,
@@ -713,9 +694,7 @@ describe("FormReact.make", () => {
 
       const onSubmit = () => {}
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: {
           password: PasswordInput,
           confirmPassword: ConfirmPasswordInput,
@@ -772,9 +751,7 @@ describe("FormReact.make", () => {
 
       const onSubmit = () => {}
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: { username: UsernameInput },
         onSubmit,
       })
@@ -906,9 +883,7 @@ describe("FormReact.make", () => {
 
       const onSubmit = () => {}
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: { fieldA: FieldAInput, fieldB: FieldBInput },
         onSubmit,
       })
@@ -985,9 +960,7 @@ describe("FormReact.make", () => {
 
       const onSubmit = () => {}
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: { password: PasswordInput, confirm: ConfirmInput },
         onSubmit,
       })
@@ -1041,9 +1014,7 @@ describe("FormReact.make", () => {
 
       const onSubmit = () => {}
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: { items: { name: ItemNameInput } },
         onSubmit,
       })
@@ -1088,7 +1059,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         mode: "onChange",
         onSubmit,
@@ -1121,7 +1091,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         mode: "onSubmit",
         onSubmit,
@@ -1152,7 +1121,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         mode: "onSubmit",
         onSubmit,
@@ -1186,9 +1154,7 @@ describe("FormReact.make", () => {
 
       const onSubmit = () => Effect.fail(new Error("Submission failed"))
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: { name: TextInput },
         onSubmit,
       })
@@ -1232,7 +1198,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
       })
@@ -1269,9 +1234,7 @@ describe("FormReact.make", () => {
 
       const onSubmit = () => Effect.void.pipe(Effect.delay("50 millis"))
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: { name: TextInput },
         onSubmit,
       })
@@ -1316,9 +1279,7 @@ describe("FormReact.make", () => {
 
       const onSubmit = () => {}
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: { name: TextInput },
         onSubmit,
       })
@@ -1359,7 +1320,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
       })
@@ -1399,7 +1359,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
       })
@@ -1446,7 +1405,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
       })
@@ -1495,7 +1453,6 @@ describe("FormReact.make", () => {
       const onSubmit = () => {}
 
       const form = FormReact.make(formBuilder, {
-        runtime: createRuntime(),
         fields: { name: TextInput },
         onSubmit,
       })
@@ -1536,9 +1493,7 @@ describe("FormReact.make", () => {
 
       const onSubmit = () => {}
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: { name: TextInput },
         onSubmit,
       })
@@ -1582,9 +1537,7 @@ describe("FormReact.make", () => {
 
       const onSubmit = () => {}
 
-      const runtime = createRuntime()
       const form = FormReact.make(formBuilder, {
-        runtime,
         fields: { name: TextInput },
         onSubmit,
       })


### PR DESCRIPTION
## Summary
- Add type overloads to `FormReact.make`: runtime is optional when `R = never`, required when `R` has services
- Default to `Atom.runtime(Layer.empty)` when runtime is not provided
- Update all tests to omit runtime except for the service injection test
- Update README examples to show optional runtime

## Test plan
- [x] All 212 tests pass
- [x] Type checking passes
- [x] Forms without service requirements work without explicit runtime
- [x] Forms with services (via `refineEffect`) still require and work with explicit runtime