### PR TITLE
add reactivityKeys option for invalidating reactive queries on submit

### DIFF
--- a/.changeset/add-reactivity-keys.md
+++ b/.changeset/add-reactivity-keys.md
@@ -1,0 +1,6 @@
+---
+"@lucas-barake/effect-form": minor
+"@lucas-barake/effect-form-react": minor
+---
+
+add `reactivityKeys` option to invalidate reactive queries after successful form submission

--- a/README.md
+++ b/README.md
@@ -463,7 +463,28 @@ The `onSubmit` callback receives:
 
 > **Note:** Auto-submit mode is only available when `args` is `void`. TypeScript will prevent using `autoSubmit: true` with custom arguments since there's no way to provide them automatically.
 
-## 16. Reusable Field Definitions
+## 16. Reactivity (Query Invalidation)
+
+Invalidate reactive queries (`AtomRpc`, `AtomHttpApi`, etc.) after successful form submission using `reactivityKeys`:
+
+```tsx
+import * as Atom from "@effect-atom/atom/Atom"
+
+const userListAtom = runtime.atom(fetchUsers).pipe(
+  Atom.withReactivity(["users"]),
+)
+
+const createUserForm = FormReact.make(formBuilder, {
+  runtime,
+  fields: { name: TextInput, email: TextInput },
+  reactivityKeys: ["users"],
+  onSubmit: (_, { decoded }) => createUser(decoded),
+})
+```
+
+After a successful submit, all atoms registered with matching keys will rebuild. Invalidation does **not** fire on validation failure or `onSubmit` effect failure.
+
+## 17. Reusable Field Definitions
 
 For fields shared across multiple forms, use `Field.makeField` to define them once:
 
@@ -507,7 +528,7 @@ const billingForm = FormBuilder.empty
   .merge(addressFields)
 ```
 
-## 17. Persisting State Across Unmounts (KeepAlive)
+## 18. Persisting State Across Unmounts (KeepAlive)
 
 By default, form state is destroyed when `Initialize` unmounts. For multi-step wizards or conditional fields where you want state to persist, use `KeepAlive`:
 

--- a/packages/form-react/src/FormReact.tsx
+++ b/packages/form-react/src/FormReact.tsx
@@ -464,6 +464,7 @@ export const make: {
       readonly runtime?: Atom.AtomRuntime<never, never>;
       readonly fields: CM;
       readonly mode?: SubmitArgs extends void ? Mode.FormMode : Mode.FormModeWithoutAutoSubmit;
+      readonly reactivityKeys?: ReadonlyArray<unknown> | Readonly<Record<string, ReadonlyArray<unknown>>> | undefined;
       readonly onSubmit: (
         args: SubmitArgs,
         ctx: {
@@ -489,6 +490,7 @@ export const make: {
       readonly runtime: Atom.AtomRuntime<R, ER>;
       readonly fields: CM;
       readonly mode?: SubmitArgs extends void ? Mode.FormMode : Mode.FormModeWithoutAutoSubmit;
+      readonly reactivityKeys?: ReadonlyArray<unknown> | Readonly<Record<string, ReadonlyArray<unknown>>> | undefined;
       readonly onSubmit: (
         args: SubmitArgs,
         ctx: {
@@ -500,7 +502,7 @@ export const make: {
     },
   ): BuiltForm<TFields, R, A, E, SubmitArgs, CM>;
 } = (self: any, options: any): any => {
-  const { fields: components, mode, onSubmit, runtime: providedRuntime } = options;
+  const { fields: components, mode, onSubmit, runtime: providedRuntime, reactivityKeys } = options;
   const runtime = providedRuntime ?? Atom.runtime(Layer.empty);
   const parsedMode = Mode.parse(mode);
   const { fields } = self;
@@ -509,6 +511,7 @@ export const make: {
     formBuilder: self,
     runtime,
     onSubmit,
+    reactivityKeys,
   });
 
   const {

--- a/packages/form-react/test/FormReact.test.tsx
+++ b/packages/form-react/test/FormReact.test.tsx
@@ -2021,4 +2021,143 @@ describe("FormReact.make", () => {
       });
     });
   });
+
+  describe("reactivity", () => {
+    it("reactivityKeys triggers invalidation after successful submit", async () => {
+      const user = userEvent.setup();
+
+      let rebuilds = 0;
+      const counterAtom = Atom.make(() => rebuilds++).pipe(
+        Atom.withReactivity(["form-submit"]),
+        Atom.keepAlive,
+      );
+
+      const NameField = Field.makeField("name", Schema.String);
+      const formBuilder = FormBuilder.empty.addField(NameField);
+
+      const form = FormReact.make(formBuilder, {
+        fields: { name: TextInput },
+        reactivityKeys: ["form-submit"],
+        onSubmit: () => {},
+      });
+
+      const CounterDisplay = () => {
+        const count = useAtomValue(counterAtom);
+        return <span data-testid="rebuild-count">{count}</span>;
+      };
+
+      const SubmitButton = makeSubmitButton(form.submit, undefined);
+
+      render(
+        <form.Initialize defaultValues={{ name: "test" }}>
+          <form.name />
+          <SubmitButton />
+          <CounterDisplay />
+        </form.Initialize>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("rebuild-count")).toHaveTextContent("0");
+      });
+
+      await user.click(screen.getByTestId("submit"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("rebuild-count")).toHaveTextContent("1");
+      });
+    });
+
+    it("no invalidation when reactivityKeys is not provided", async () => {
+      const user = userEvent.setup();
+      const submitHandler = vi.fn();
+
+      let rebuilds = 0;
+      const counterAtom = Atom.make(() => rebuilds++).pipe(
+        Atom.withReactivity(["no-keys-test"]),
+        Atom.keepAlive,
+      );
+
+      const NameField = Field.makeField("name", Schema.String);
+      const formBuilder = FormBuilder.empty.addField(NameField);
+
+      const form = FormReact.make(formBuilder, {
+        fields: { name: TextInput },
+        onSubmit: () => submitHandler(),
+      });
+
+      const CounterDisplay = () => {
+        const count = useAtomValue(counterAtom);
+        return <span data-testid="rebuild-count">{count}</span>;
+      };
+
+      const SubmitButton = makeSubmitButton(form.submit, undefined);
+
+      render(
+        <form.Initialize defaultValues={{ name: "test" }}>
+          <form.name />
+          <SubmitButton />
+          <CounterDisplay />
+        </form.Initialize>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("rebuild-count")).toHaveTextContent("0");
+      });
+
+      await user.click(screen.getByTestId("submit"));
+
+      await waitFor(() => {
+        expect(submitHandler).toHaveBeenCalled();
+      });
+
+      expect(screen.getByTestId("rebuild-count")).toHaveTextContent("0");
+    });
+
+    it("no invalidation on validation failure", async () => {
+      const user = userEvent.setup();
+
+      let rebuilds = 0;
+      const counterAtom = Atom.make(() => rebuilds++).pipe(
+        Atom.withReactivity(["validation-fail-test"]),
+        Atom.keepAlive,
+      );
+
+      const NonEmpty = Schema.String.pipe(Schema.minLength(1, { message: () => "Required" }));
+      const NameField = Field.makeField("name", NonEmpty);
+      const formBuilder = FormBuilder.empty.addField(NameField);
+
+      const form = FormReact.make(formBuilder, {
+        fields: { name: TextInput },
+        reactivityKeys: ["validation-fail-test"],
+        onSubmit: () => {},
+      });
+
+      const CounterDisplay = () => {
+        const count = useAtomValue(counterAtom);
+        return <span data-testid="rebuild-count">{count}</span>;
+      };
+
+      const SubmitButton = makeSubmitButton(form.submit, undefined);
+
+      render(
+        <form.Initialize defaultValues={{ name: "" }}>
+          <form.name />
+          <SubmitButton />
+          <CounterDisplay />
+        </form.Initialize>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("rebuild-count")).toHaveTextContent("0");
+      });
+
+      await user.click(screen.getByTestId("submit"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("error")).toHaveTextContent("Required");
+      });
+
+      expect(screen.getByTestId("rebuild-count")).toHaveTextContent("0");
+    });
+  });
 });

--- a/packages/form/src/FormAtoms.ts
+++ b/packages/form/src/FormAtoms.ts
@@ -22,6 +22,7 @@ export interface FieldAtoms {
 export interface FormAtomsConfig<TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = void> {
   readonly runtime: Atom.AtomRuntime<R, any>;
   readonly formBuilder: FormBuilder.FormBuilder<TFields, R>;
+  readonly reactivityKeys?: ReadonlyArray<unknown> | Readonly<Record<string, ReadonlyArray<unknown>>> | undefined;
   readonly onSubmit: (
     args: SubmitArgs,
     ctx: {
@@ -309,40 +310,42 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
   };
 
   const submitAtom = runtime
-    .fn<SubmitArgs>()((args, get) =>
-      Effect.gen(function*() {
-        const state = get(stateAtom);
-        if (Option.isNone(state)) return yield* Effect.die("Form not initialized");
-        const values = state.value.values;
-        get.set(errorsAtom, new Map());
-        const decoded = yield* pipe(
-          Schema.decodeUnknown(combinedSchema, { errors: "all" })(values) as Effect.Effect<
-            Field.DecodedFromFields<TFields>,
-            ParseResult.ParseError,
-            R
-          >,
-          Effect.tapError((parseError) =>
-            Effect.sync(() => {
-              const routedErrors = Validation.routeErrorsWithSource(parseError);
-              get.set(errorsAtom, routedErrors);
-              get.set(stateAtom, Option.some(operations.createSubmitState(state.value)));
-            })
-          ),
-        );
-        const submitState = operations.createSubmitState(state.value);
-        get.set(
-          stateAtom,
-          Option.some({
-            ...submitState,
-            lastSubmittedValues: Option.some({ encoded: values, decoded }),
-          }),
-        );
-        const result = config.onSubmit(args, { decoded, encoded: values, get });
-        if (Effect.isEffect(result)) {
-          return yield* result as Effect.Effect<A, E, R>;
-        }
-        return result as A;
-      })
+    .fn<SubmitArgs>()(
+      (args, get) =>
+        Effect.gen(function*() {
+          const state = get(stateAtom);
+          if (Option.isNone(state)) return yield* Effect.die("Form not initialized");
+          const values = state.value.values;
+          get.set(errorsAtom, new Map());
+          const decoded = yield* pipe(
+            Schema.decodeUnknown(combinedSchema, { errors: "all" })(values) as Effect.Effect<
+              Field.DecodedFromFields<TFields>,
+              ParseResult.ParseError,
+              R
+            >,
+            Effect.tapError((parseError) =>
+              Effect.sync(() => {
+                const routedErrors = Validation.routeErrorsWithSource(parseError);
+                get.set(errorsAtom, routedErrors);
+                get.set(stateAtom, Option.some(operations.createSubmitState(state.value)));
+              })
+            ),
+          );
+          const submitState = operations.createSubmitState(state.value);
+          get.set(
+            stateAtom,
+            Option.some({
+              ...submitState,
+              lastSubmittedValues: Option.some({ encoded: values, decoded }),
+            }),
+          );
+          const result = config.onSubmit(args, { decoded, encoded: values, get });
+          if (Effect.isEffect(result)) {
+            return yield* result as Effect.Effect<A, E, R>;
+          }
+          return result as A;
+        }),
+      config.reactivityKeys ? { reactivityKeys: config.reactivityKeys } : undefined,
     )
     .pipe(Atom.setIdleTTL(0)) as Atom.AtomResultFn<SubmitArgs, A, E | ParseResult.ParseError>;
 


### PR DESCRIPTION
Passes reactivityKeys through to runtime.fn() so form submit triggers Reactivity.mutation, allowing users to invalidate reactive queries (e.g. AtomRpc/AtomHttpApi) after successful submission. Closes #55.