### PR TITLE
support updater function for setValues

### DIFF
--- a/.changeset/set-values-updater.md
+++ b/.changeset/set-values-updater.md
@@ -1,0 +1,6 @@
+---
+"@lucas-barake/effect-form": minor
+"@lucas-barake/effect-form-react": minor
+---
+
+support updater function for `setValues`

--- a/packages/form-react/src/FormReact.tsx
+++ b/packages/form-react/src/FormReact.tsx
@@ -74,7 +74,7 @@ export type BuiltForm<
   readonly submit: Atom.AtomResultFn<SubmitArgs, A, E | ParseResult.ParseError>
   readonly reset: Atom.Writable<void, void>
   readonly revertToLastSubmit: Atom.Writable<void, void>
-  readonly setValues: Atom.Writable<void, Field.EncodedFromFields<TFields>>
+  readonly setValues: Atom.Writable<void, FormAtoms.SetValuesArg<TFields>>
   readonly getFieldAtoms: <S,>(field: FormBuilder.FieldRef<S>) => FormAtoms.PublicFieldAtoms<S>
 
   readonly mount: Atom.Atom<void>

--- a/packages/form/src/FormAtoms.ts
+++ b/packages/form/src/FormAtoms.ts
@@ -35,6 +35,10 @@ export interface PublicFieldAtoms<E,> {
   readonly setTouched: Atom.Writable<void, boolean>
 }
 
+export type SetValuesArg<TFields extends Field.FieldsRecord,> =
+  | Field.EncodedFromFields<TFields>
+  | ((prev: Field.EncodedFromFields<TFields>) => Field.EncodedFromFields<TFields>)
+
 export interface FormAtomsConfig<TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = void,> {
   readonly runtime: Atom.AtomRuntime<R, any>
   readonly formBuilder: FormBuilder.FormBuilder<TFields, R>
@@ -95,7 +99,7 @@ export interface FormAtoms<TFields extends Field.FieldsRecord, R, A = void, E = 
 
   readonly resetAtom: Atom.Writable<void, void>
   readonly revertToLastSubmitAtom: Atom.Writable<void, void>
-  readonly setValuesAtom: Atom.Writable<void, Field.EncodedFromFields<TFields>>
+  readonly setValuesAtom: Atom.Writable<void, SetValuesArg<TFields>>
 
   readonly getFieldAtoms: <S,>(field: FormBuilder.FieldRef<S>) => PublicFieldAtoms<S>
 
@@ -646,11 +650,14 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
     { initialValue: undefined as void }
   ).pipe(Atom.setIdleTTL(0))
 
-  const setValuesAtom = Atom.fnSync<Field.EncodedFromFields<TFields>>()(
-    (_values, get) => {
+  const setValuesAtom = Atom.fnSync<SetValuesArg<TFields>>()(
+    (update, get) => {
       const state = get(stateAtom)
       if (Option.isNone(state)) return
-      get.set(stateAtom, Option.some(operations.setFormValues(state.value, _values)))
+      const values = typeof update === "function"
+        ? (update as (prev: Field.EncodedFromFields<TFields>) => Field.EncodedFromFields<TFields>)(state.value.values)
+        : update
+      get.set(stateAtom, Option.some(operations.setFormValues(state.value, values)))
       get.set(errorsAtom, new Map())
     },
     { initialValue: undefined as void }

--- a/packages/form/test/FormAtoms.test.ts
+++ b/packages/form/test/FormAtoms.test.ts
@@ -1104,6 +1104,30 @@ describe("FormAtoms", () => {
       expect(newState.dirtyFields.has("email")).toBe(true)
       expect(registry.get(atoms.errorsAtom).size).toBe(0)
     })
+
+    it("accepts an updater function that receives current values", () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const form = makeTestForm()
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit: () => {} })
+      const registry = Registry.make()
+
+      const initialState = atoms.operations.createInitialState({
+        name: "John",
+        email: "john@test.com"
+      })
+      registry.set(atoms.stateAtom, Option.some(initialState))
+      registry.set(atoms.errorsAtom, new Map([["email", { message: "Invalid email", source: "field" }]]))
+
+      registry.mount(atoms.setValuesAtom)
+      registry.set(atoms.setValuesAtom, (prev) => ({ ...prev, name: "Alice" }))
+
+      const newState = registry.get(atoms.stateAtom).pipe(Option.getOrThrow)
+      expect(newState.values.name).toBe("Alice")
+      expect(newState.values.email).toBe("john@test.com")
+      expect(newState.dirtyFields.has("name")).toBe(true)
+      expect(newState.dirtyFields.has("email")).toBe(false)
+      expect(registry.get(atoms.errorsAtom).size).toBe(0)
+    })
   })
 
   describe("getFieldAtoms", () => {


### PR DESCRIPTION
setValues now accepts either a direct values object or an updater function `(prev) => next`, matching the pattern already used by per-field setValue.