### PR TITLE
use Atom.Writable for setValues instead of manual updater handling

### DIFF
--- a/.changeset/setvalues-writable.md
+++ b/.changeset/setvalues-writable.md
@@ -1,0 +1,6 @@
+---
+"@lucas-barake/effect-form": minor
+"@lucas-barake/effect-form-react": minor
+---
+
+use `Atom.Writable` for `setValues` instead of manual updater function handling — updater callbacks are supported out of the box via `registry.update`

--- a/README.md
+++ b/README.md
@@ -233,14 +233,12 @@ function FormControls() {
       <button onClick={() => setAllValues({ email: "reset@email.com", password: "" })}>
         Reset to Defaults
       </button>
-
-      <button onClick={() => setAllValues((prev) => ({ ...prev, email: "updated@email.com" }))}>
-        Update Email Only
-      </button>
     </>
   )
 }
 ```
+
+> `setValues` is an `Atom.Writable` — you can also use `registry.update` from Atom's context for type-safe updater callbacks: `registry.update(form.setValues, (prev) => ({ ...prev, email: "new" }))`.
 
 ## 8. Auto-Submit Mode
 
@@ -631,7 +629,7 @@ Operations are AtomResultFns - use `useAtomSet` to invoke:
 ```ts
 form.reset // AtomResultFn<void> - reset to initial values
 form.revertToLastSubmit // AtomResultFn<void> - revert to last submit
-form.setValues // AtomResultFn<Values | (prev => Values)> - set all values
+form.setValues // Writable<Values> - set all values (supports updater via registry.update)
 form.submit // AtomResultFn<void, A, E> - trigger submit (handler defined at build)
 ```
 

--- a/packages/form-react/src/FormReact.tsx
+++ b/packages/form-react/src/FormReact.tsx
@@ -74,7 +74,7 @@ export type BuiltForm<
   readonly submit: Atom.AtomResultFn<SubmitArgs, A, E | ParseResult.ParseError>
   readonly reset: Atom.Writable<void, void>
   readonly revertToLastSubmit: Atom.Writable<void, void>
-  readonly setValues: Atom.Writable<void, FormAtoms.SetValuesArg<TFields>>
+  readonly setValues: Atom.Writable<Field.EncodedFromFields<TFields>>
   readonly getFieldAtoms: <S,>(field: FormBuilder.FieldRef<S>) => FormAtoms.PublicFieldAtoms<S>
 
   readonly mount: Atom.Atom<void>

--- a/packages/form/src/FormAtoms.ts
+++ b/packages/form/src/FormAtoms.ts
@@ -35,10 +35,6 @@ export interface PublicFieldAtoms<E,> {
   readonly setTouched: Atom.Writable<void, boolean>
 }
 
-export type SetValuesArg<TFields extends Field.FieldsRecord,> =
-  | Field.EncodedFromFields<TFields>
-  | ((prev: Field.EncodedFromFields<TFields>) => Field.EncodedFromFields<TFields>)
-
 export interface FormAtomsConfig<TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = void,> {
   readonly runtime: Atom.AtomRuntime<R, any>
   readonly formBuilder: FormBuilder.FormBuilder<TFields, R>
@@ -99,7 +95,7 @@ export interface FormAtoms<TFields extends Field.FieldsRecord, R, A = void, E = 
 
   readonly resetAtom: Atom.Writable<void, void>
   readonly revertToLastSubmitAtom: Atom.Writable<void, void>
-  readonly setValuesAtom: Atom.Writable<void, SetValuesArg<TFields>>
+  readonly setValuesAtom: Atom.Writable<Field.EncodedFromFields<TFields>>
 
   readonly getFieldAtoms: <S,>(field: FormBuilder.FieldRef<S>) => PublicFieldAtoms<S>
 
@@ -650,17 +646,19 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
     { initialValue: undefined as void }
   ).pipe(Atom.setIdleTTL(0))
 
-  const setValuesAtom = Atom.fnSync<SetValuesArg<TFields>>()(
-    (update, get) => {
-      const state = get(stateAtom)
+  const setValuesAtom = Atom.writable(
+    (get): Field.EncodedFromFields<TFields> =>
+      pipe(
+        get(stateAtom),
+        Option.map((s) => s.values),
+        Option.getOrElse(() => undefined as never)
+      ),
+    (ctx, values: Field.EncodedFromFields<TFields>) => {
+      const state = ctx.get(stateAtom)
       if (Option.isNone(state)) return
-      const values = typeof update === "function"
-        ? (update as (prev: Field.EncodedFromFields<TFields>) => Field.EncodedFromFields<TFields>)(state.value.values)
-        : update
-      get.set(stateAtom, Option.some(operations.setFormValues(state.value, values)))
-      get.set(errorsAtom, new Map())
-    },
-    { initialValue: undefined as void }
+      ctx.set(stateAtom, Option.some(operations.setFormValues(state.value, values)))
+      ctx.set(errorsAtom, new Map())
+    }
   ).pipe(Atom.setIdleTTL(0))
 
   const setValueAtomsRegistry = createWeakRegistry<Atom.Writable<void, any>>()

--- a/packages/form/test/FormAtoms.test.ts
+++ b/packages/form/test/FormAtoms.test.ts
@@ -1119,7 +1119,7 @@ describe("FormAtoms", () => {
       registry.set(atoms.errorsAtom, new Map([["email", { message: "Invalid email", source: "field" }]]))
 
       registry.mount(atoms.setValuesAtom)
-      registry.set(atoms.setValuesAtom, (prev) => ({ ...prev, name: "Alice" }))
+      registry.update(atoms.setValuesAtom, (prev) => ({ ...prev, name: "Alice" }))
 
       const newState = registry.get(atoms.stateAtom).pipe(Option.getOrThrow)
       expect(newState.values.name).toBe("Alice")


### PR DESCRIPTION
The previous setValues implementation manually discriminated updater functions via `typeof update === "function"` with a custom `SetValuesArg` union type. This is unnecessary — Effect Atom's `registry.update` and `useAtomSet` support updater callbacks natively on any `Atom.Writable`.

Switches `setValuesAtom` from `Atom.fnSync` to `Atom.writable` and removes `SetValuesArg`.