### PR TITLE
feat: expose fields' `path` in FieldState

### DIFF
--- a/.changeset/expose-field-path.md
+++ b/.changeset/expose-field-path.md
@@ -1,0 +1,6 @@
+---
+"@lucas-barake/effect-form": minor
+"@lucas-barake/effect-form-react": minor
+---
+
+Expose `path` property in `FieldState` for use in field `name` and `id` attributes.

--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ form.validate // AtomResultFn<void> - trigger full schema validation without sub
 
 ```ts
 interface FieldState<E,> {
+  path: string // Dot-notation path identifying the field (e.g. "name", "items[0].street")
   value: E // Current field value (encoded type)
   onChange: (value: E) => void
   onBlur: () => void

--- a/packages/form-react/src/FormReact.tsx
+++ b/packages/form-react/src/FormReact.tsx
@@ -160,6 +160,7 @@ const makeFieldComponent = <S extends Schema.Schema.Any, P,>(
 
     const fieldState = React.useMemo(
       () => ({
+        path: fieldPath,
         value,
         onChange,
         onBlur,
@@ -168,7 +169,7 @@ const makeFieldComponent = <S extends Schema.Schema.Any, P,>(
         isValidating,
         isDirty
       }),
-      [value, onChange, onBlur, displayError, isTouched, isValidating, isDirty]
+      [fieldPath, value, onChange, onBlur, displayError, isTouched, isValidating, isDirty]
     )
 
     return <Component field={fieldState} props={extraProps} />

--- a/packages/form-react/test/FormReact.test.tsx
+++ b/packages/form-react/test/FormReact.test.tsx
@@ -624,6 +624,65 @@ describe("FormReact.make", () => {
     })
   })
 
+  describe("field path", () => {
+    it("exposes the field key as path for top-level fields", () => {
+      const NameField = Field.makeField("name", Schema.String)
+      const formBuilder = FormBuilder.empty.addField(NameField)
+
+      const PathInput: FormReact.FieldComponent<string> = ({ field }) => (
+        <span data-testid="field-path">{field.path}</span>
+      )
+
+      const form = FormReact.make(formBuilder, {
+        fields: { name: PathInput },
+        onSubmit: () => {}
+      })
+
+      render(
+        <form.Initialize defaultValues={{ name: "" }}>
+          <form.name />
+        </form.Initialize>
+      )
+
+      expect(screen.getByTestId("field-path")).toHaveTextContent("name")
+    })
+
+    it("exposes the correct nested path for fields inside array items", () => {
+      const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+      const formBuilder = FormBuilder.empty.addField(ItemsArrayField)
+
+      const ItemPathInput: FormReact.FieldComponent<string> = ({ field }) => (
+        <span data-testid="field-path">{field.path}</span>
+      )
+
+      const form = FormReact.make(formBuilder, {
+        fields: { items: { name: ItemPathInput } },
+        onSubmit: () => {}
+      })
+
+      render(
+        <form.Initialize defaultValues={{ items: [{ name: "A" }, { name: "B" }] }}>
+          <form.items>
+            {({ items }) => (
+              <>
+                {items.map((_, i) => (
+                  <form.items.Item key={i} index={i}>
+                    <form.items.name />
+                  </form.items.Item>
+                ))}
+              </>
+            )}
+          </form.items>
+        </form.Initialize>
+      )
+
+      const paths = screen.getAllByTestId("field-path")
+      expect(paths).toHaveLength(2)
+      expect(paths[0]).toHaveTextContent("items[0].name")
+      expect(paths[1]).toHaveTextContent("items[1].name")
+    })
+  })
+
   describe("async validation", () => {
     it("submit works with async schema validation (filterEffect)", async () => {
       const user = userEvent.setup()

--- a/packages/form/src/FieldState.ts
+++ b/packages/form/src/FieldState.ts
@@ -4,6 +4,7 @@ import type * as Schema from "effect/Schema"
 export type FieldValue<T,> = T extends Schema.Schema.Any ? Schema.Schema.Encoded<T> : T
 
 export interface FieldState<E,> {
+  readonly path: string
   readonly value: E
   readonly onChange: (value: E) => void
   readonly onBlur: () => void


### PR DESCRIPTION
Amazing library, Lucas! In adapting it to my use cases, the first issue I encountered is it's not easy to get data for the fields' `name` and `id` property (important for accessibility, among others).

This PR is tiny, it exposes the field's `path` in `FieldState` so that we can use it in the field renderers. Example usage:

```ts
const TextInput: FormReact.FieldComponent<string, TextFieldProps> = ({ field, props }) => {
  const { formId } = useFieldMeta()
  const fieldId = `${formId}-${field.path}`

  return (
    <Field>
      <FieldLabel htmlFor={fieldId}>
        <FieldTitle>{props.label}</FieldTitle>
        {props.description && <FieldDescription>{props.description}</FieldDescription>}
      </FieldLabel>
      <FieldContent>
        <Input
          id={fieldId}
          name={field.path}
          value={field.value}
          onChange={(e) => field.onChange(e.target.value)}
          onBlur={field.onBlur}
          aria-invalid={Option.isSome(field.error)}
        />
        {Option.isSome(field.error) && <FieldError>{field.error.value}</FieldError>}
      </FieldContent>
    </Field>
  )
}
```

Thanks in advance for your attention!