### PR TITLE
fix: default array schemas to [] in getDefaultFromSchema

### DIFF
--- a/.changeset/array-default-schemas.md
+++ b/.changeset/array-default-schemas.md
@@ -1,0 +1,5 @@
+---
+"@lucas-barake/effect-form": patch
+---
+
+default array schemas to `[]` in `getDefaultFromSchema`

--- a/packages/form/src/Field.ts
+++ b/packages/form/src/Field.ts
@@ -65,6 +65,8 @@ export const getDefaultFromSchema = (schema: Schema.Top): unknown => {
       return 0
     case "Boolean":
       return false
+    case "Arrays":
+      return []
     case "Literal":
       return ast.literal
     case "Enum": {

--- a/packages/form/test/ArrayDefault.regression.test.ts
+++ b/packages/form/test/ArrayDefault.regression.test.ts
@@ -1,0 +1,40 @@
+import * as Layer from "effect/Layer"
+import * as Schema from "effect/Schema"
+import * as Atom from "effect/unstable/reactivity/Atom"
+import { describe, expect, it } from "vitest"
+import * as Field from "../src/Field.js"
+import * as FormAtoms from "../src/FormAtoms.js"
+import * as FormBuilder from "../src/FormBuilder.js"
+
+describe("getDefaultFromSchema arrays (regression)", () => {
+  it("top-level array schema defaults to []", () => {
+    expect(Field.getDefaultFromSchema(Schema.Array(Schema.String))).toEqual([])
+  })
+
+  it("array property inside a struct defaults to []", () => {
+    const itemSchema = Schema.Struct({
+      name: Schema.String,
+      tags: Schema.Array(Schema.String)
+    })
+    expect(Field.getDefaultFromSchema(itemSchema)).toEqual({ name: "", tags: [] })
+  })
+
+  it("appendArrayItem produces a valid item when item schema has a nested array", () => {
+    const runtime = Atom.runtime(Layer.empty)
+    const ItemSchema = Schema.Struct({
+      name: Schema.String,
+      tags: Schema.Array(Schema.String)
+    })
+    const ItemsField = Field.makeArrayField("items", ItemSchema)
+    const form = FormBuilder.empty.addField(ItemsField)
+    const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit: () => {} })
+
+    const initialState = atoms.operations.createInitialState({ items: [] })
+    const newState = atoms.operations.appendArrayItem(initialState, "items", ItemSchema)
+
+    // The appended default item must round-trip through the item schema.
+    expect(newState.values.items).toHaveLength(1)
+    expect(() => Schema.decodeUnknownSync(ItemSchema)(newState.values.items[0])).not.toThrow()
+    expect(newState.values.items[0]).toEqual({ name: "", tags: [] })
+  })
+})


### PR DESCRIPTION
## Summary

`getDefaultFromSchema` discriminates on `AST.toEncoded(schema.ast)._tag` but had no case for v4's `"Arrays"` tag (`SchemaAST.ts` tags both arrays and tuples as `Arrays`), so any array type fell through to `default: return ""`.

This is reachable through the public `operations.appendArrayItem`: appending an item without an explicit value on an array field whose item schema contains a nested array produced `""` where an array is required — the item then fails decoding with `Expected array, got ""`.

## Fix

Add the missing `"Arrays"` case returning `[]`.

## Tests

Added `packages/form/test/ArrayDefault.regression.test.ts` (3 cases: top-level array default, array-in-struct default, `appendArrayItem` end-to-end producing a decodable item). Red before the fix (`Expected array, got ""`), green after. Full suite: 304 passed.
