### PR TITLE
refactor: use AsyncResult accessors instead of manual result inspection

### DIFF
--- a/.changeset/asyncresult-accessors.md
+++ b/.changeset/asyncresult-accessors.md
@@ -1,0 +1,5 @@
+---
+"@lucas-barake/effect-form": patch
+---
+
+use AsyncResult accessors instead of manual result inspection in display-error logic

--- a/packages/form/src/FormAtoms.ts
+++ b/packages/form/src/FormAtoms.ts
@@ -1,8 +1,8 @@
-import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import { pipe } from "effect/Function"
 import * as Option from "effect/Option"
 import * as Schema from "effect/Schema"
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
 import * as Field from "./Field.ts"
 import * as FormBuilder from "./FormBuilder.ts"
@@ -381,21 +381,14 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
       const isTouched = get(touchedAtom)
       const submitCount = get(submitCountAtom)
 
-      let livePerFieldError: Option.Option<string> = Option.none()
-      if (validationResult._tag === "Failure") {
-        const parseError = Cause.findErrorOption(validationResult.cause)
-        if (Option.isSome(parseError) && Schema.isSchemaError(parseError.value)) {
-          livePerFieldError = Validation.extractFirstError(parseError.value)
-        }
-      }
+      const livePerFieldError = Option.flatMap(AsyncResult.error(validationResult), Validation.extractFirstError)
 
       let validationError: Option.Option<string> = Option.none()
       if (Option.isSome(livePerFieldError)) {
         validationError = livePerFieldError
       } else if (Option.isSome(storedError)) {
-        const isValidating = validationResult.waiting
         const shouldHideStoredError = storedError.value.source === "field" &&
-          (validationResult._tag === "Success" || isValidating)
+          (AsyncResult.isSuccess(validationResult) || AsyncResult.isWaiting(validationResult))
         if (!shouldHideStoredError) {
           validationError = Option.some(storedError.value.message)
         }
@@ -799,7 +792,9 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
       })
     ).pipe(Atom.setIdleTTL(0))
 
-    const isValidating = Atom.readable((get) => get(internal.validationAtom).waiting).pipe(Atom.setIdleTTL(0))
+    const isValidating = Atom.readable((get) => AsyncResult.isWaiting(get(internal.validationAtom))).pipe(
+      Atom.setIdleTTL(0)
+    )
 
     const setValueAtom = setValueFamily(fieldKey)
 
@@ -857,7 +852,7 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
       const debounceMs = parsedMode.debounce
 
       const triggerSubmit = () => {
-        if (get.once(submitAtom).waiting) {
+        if (AsyncResult.isWaiting(get.once(submitAtom))) {
           pendingChanges = true
           return
         }
@@ -888,7 +883,7 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
         lastValues = currentValues
 
         const submitResult = get.once(submitAtom)
-        if (submitResult.waiting) {
+        if (AsyncResult.isWaiting(submitResult)) {
           pendingChanges = true
         } else {
           debouncedSubmit()
@@ -897,7 +892,7 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
 
       get.subscribe(submitAtom, () => {
         const result = get.once(submitAtom)
-        const isSubmitting = result.waiting
+        const isSubmitting = AsyncResult.isWaiting(result)
         const justFinished = wasSubmitting && !isSubmitting
         // Update wasSubmitting BEFORE triggering a follow-up submit. debouncedSubmit
         // (no debounce) synchronously re-enters this subscription with the new
@@ -914,7 +909,7 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
 
   const onBlurSubmitAtom: Atom.Writable<void, void> = parsedMode.autoSubmit && parsedMode.validation === "onBlur"
     ? Atom.fnSync<void>()((_: void, get) => {
-      if (get(submitAtom).waiting) return
+      if (AsyncResult.isWaiting(get(submitAtom))) return
       const stateOption = get(stateAtom)
       if (Option.isNone(stateOption)) return
       const { lastSubmittedValues, values } = stateOption.value

--- a/packages/form/test/FormAtoms.test.ts
+++ b/packages/form/test/FormAtoms.test.ts
@@ -2045,6 +2045,41 @@ describe("FormAtoms", () => {
       )
     })
 
+    it("hides stored field-source error while validation is re-running", () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const NameField = Field.makeField(
+        "name",
+        Schema.String.pipe(Schema.decode({
+          decode: SchemaGetter.checkEffect(() => Effect.never),
+          encode: SchemaGetter.passthrough()
+        }))
+      )
+      const EmailField = Field.makeField("email", Schema.String)
+      const form = FormBuilder.empty.addField(NameField).addField(EmailField)
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit: () => {}, mode: { validation: "onSubmit" } })
+      const registry = AtomRegistry.make()
+
+      let state = atoms.operations.createInitialState({ name: "John", email: "test@test.com" })
+      state = atoms.operations.createSubmitState(state)
+      registry.set(atoms.stateAtom, Option.some(state))
+      registry.set(atoms.errorsAtom, new Map([["name", { message: "Name error", source: "field" as const }]]))
+
+      const fieldAtoms = atoms.getOrCreateFieldAtoms("name", NameField.schema)
+      registry.mount(fieldAtoms.displayErrorAtom)
+      registry.mount(fieldAtoms.validationAtom)
+
+      expect(registry.get(fieldAtoms.displayErrorAtom)).toEqual(Option.some("Name error"))
+
+      registry.set(fieldAtoms.validationAtom, "John")
+
+      return new Promise<void>((resolve) =>
+        setTimeout(() => {
+          expect(Option.isNone(registry.get(fieldAtoms.displayErrorAtom))).toBe(true)
+          resolve()
+        }, 50)
+      )
+    })
+
     it("keeps stored refinement error even when validation passes", () => {
       const runtime = Atom.runtime(Layer.empty)
       const form = makeTestForm()


### PR DESCRIPTION
## What

Replaces hand-rolled inspection of `AsyncResult` values in `FormAtoms.ts` with the accessors effect v4 already ships in `effect/unstable/reactivity/AsyncResult`:

- `displayErrorAtom`: the manual `_tag === "Failure"` + `Cause.findErrorOption` + `Schema.isSchemaError` block collapses to `Option.flatMap(AsyncResult.error(validationResult), Validation.extractFirstError)`. `AsyncResult.error` is exactly `self._tag === "Failure" ? Cause.findErrorOption(self.cause) : Option.none()`, and the validation atom's error channel is statically `Schema.SchemaError`, so the `isSchemaError` re-guard was redundant.
- `_tag === "Success"` → `AsyncResult.isSuccess`.
- Raw `.waiting` reads (`displayErrorAtom`, `isValidating`, `autoSubmitAtom`, `onBlurSubmitAtom`) → `AsyncResult.isWaiting`.
- Dropped the now-unused `Cause` import.

## Behavior

No behavior change. Added one focused test locking the previously untested branch: a stored `field`-source error is hidden while validation is re-running (`waiting`), alongside the existing test covering the validation-success case.

## Verification

- `pnpm check:types` clean
- `pnpm vitest run`: 302 tests passed (9 files)
- `pnpm lint` clean