### PR TITLE
refactor: flatten builder field intersections for readable hover types

### DIFF
--- a/.changeset/simplify-builder-types.md
+++ b/.changeset/simplify-builder-types.md
@@ -1,0 +1,5 @@
+---
+"@lucas-barake/effect-form": patch
+---
+
+flatten builder field intersections for readable hover types

--- a/packages/form/src/FormBuilder.ts
+++ b/packages/form/src/FormBuilder.ts
@@ -15,6 +15,17 @@ import type {
 } from "./Field.ts"
 import { isArrayFieldDef, isFieldDef, makeField } from "./Field.ts"
 
+/**
+ * Flattens an intersection of field records into a single object type so that
+ * hover types and error messages display as `{ email: ...; password: ... }`
+ * instead of `{ email: ... } & { password: ... } & ...`.
+ *
+ * Note: `Types.Simplify` from effect is not used here because its
+ * `extends infer B ? B : never` indirection erases the `FieldsRecord`
+ * constraint in generic positions.
+ */
+type Simplify<T,> = { readonly [K in keyof T]: T[K] } & {}
+
 export interface SubmittedValues<TFields extends FieldsRecord,> {
   readonly encoded: EncodedFromFields<TFields>
   readonly decoded: DecodedFromFields<TFields>
@@ -71,23 +82,26 @@ export interface FormBuilder<TFields extends FieldsRecord, R,> {
   addField<K extends string, S extends Schema.Top,>(
     this: FormBuilder<TFields, R>,
     field: FieldDef<K, S>
-  ): FormBuilder<TFields & { readonly [key in K]: FieldDef<K, S> }, R | Schema.Codec.DecodingServices<S>>
+  ): FormBuilder<Simplify<TFields & { readonly [key in K]: FieldDef<K, S> }>, R | Schema.Codec.DecodingServices<S>>
 
   addField<K extends string, S extends Schema.Top,>(
     this: FormBuilder<TFields, R>,
     field: ArrayFieldDef<K, S>
-  ): FormBuilder<TFields & { readonly [key in K]: ArrayFieldDef<K, S> }, R | Schema.Codec.DecodingServices<S>>
+  ): FormBuilder<
+    Simplify<TFields & { readonly [key in K]: ArrayFieldDef<K, S> }>,
+    R | Schema.Codec.DecodingServices<S>
+  >
 
   addField<K extends string, S extends Schema.Top,>(
     this: FormBuilder<TFields, R>,
     key: K,
     schema: S
-  ): FormBuilder<TFields & { readonly [key in K]: FieldDef<K, S> }, R | Schema.Codec.DecodingServices<S>>
+  ): FormBuilder<Simplify<TFields & { readonly [key in K]: FieldDef<K, S> }>, R | Schema.Codec.DecodingServices<S>>
 
   merge<TFields2 extends FieldsRecord, R2,>(
     this: FormBuilder<TFields, R>,
     other: FormBuilder<TFields2, R2>
-  ): FormBuilder<TFields & TFields2, R | R2>
+  ): FormBuilder<Simplify<TFields & TFields2>, R | R2>
 
   refine(
     this: FormBuilder<TFields, R>,

--- a/packages/form/test/FormBuilder.types.test.ts
+++ b/packages/form/test/FormBuilder.types.test.ts
@@ -1,0 +1,49 @@
+import * as Schema from "effect/Schema"
+import { describe, expectTypeOf, it } from "vitest"
+import type * as Field from "../src/Field.js"
+import * as FormBuilder from "../src/FormBuilder.js"
+
+type FieldsOf<B,> = B extends FormBuilder.FormBuilder<infer F, any> ? F : never
+
+describe("FormBuilder type display", () => {
+  const builder = FormBuilder.empty
+    .addField("email", Schema.String)
+    .addField("age", Schema.Number)
+    .addField("active", Schema.Boolean)
+
+  type TFields = FieldsOf<typeof builder>
+
+  type FlatFields = {
+    readonly email: Field.FieldDef<"email", typeof Schema.String>
+    readonly age: Field.FieldDef<"age", typeof Schema.Number>
+    readonly active: Field.FieldDef<"active", typeof Schema.Boolean>
+  }
+
+  it("EncodedFromFields of a 3-field builder is the expected flat object type", () => {
+    expectTypeOf<Field.EncodedFromFields<TFields>>().toEqualTypeOf<{
+      readonly email: string
+      readonly age: number
+      readonly active: boolean
+    }>()
+  })
+
+  it("the builder's TFields parameter is assignable to/from the flat record form", () => {
+    expectTypeOf<TFields>().toExtend<FlatFields>()
+    expectTypeOf<FlatFields>().toExtend<TFields>()
+    expectTypeOf<TFields>().toEqualTypeOf<FlatFields>()
+  })
+
+  it("merge produces the flattened union of both builders' fields", () => {
+    const other = FormBuilder.empty.addField("name", Schema.String)
+    const merged = builder.merge(other)
+    type Merged = FieldsOf<typeof merged>
+
+    expectTypeOf<Merged>().toEqualTypeOf<{
+      readonly email: Field.FieldDef<"email", typeof Schema.String>
+      readonly age: Field.FieldDef<"age", typeof Schema.Number>
+      readonly active: Field.FieldDef<"active", typeof Schema.Boolean>
+      readonly name: Field.FieldDef<"name", typeof Schema.String>
+    }>()
+    expectTypeOf<keyof Merged>().toEqualTypeOf<"email" | "age" | "active" | "name">()
+  })
+})


### PR DESCRIPTION
## Problem

Each `addField` overload returns `FormBuilder<TFields & { readonly [key in K]: FieldDef<K, S> }, ...>` and `merge` returns `FormBuilder<TFields & TFields2, ...>`. On a form with many fields, hover types and error messages display as a chain of raw intersections, which gets noisy fast.

## Change

Applied a `Simplify` type to the `TFields` result position of all three `addField` overloads and `merge` in `packages/form/src/FormBuilder.ts`. The proto implementation is untouched (it is untyped internally), and downstream consumers (`FieldRefs`, `EncodedFromFields`/`DecodedFromFields`, the React/Solid `FieldComponentMap`, `SubmittedValues`) only map over `keyof TFields`, so inference is unchanged — the full typecheck over all packages and tests stays green with zero test changes.

Note: effect does export `Types.Simplify`, but its `extends infer B ? B : never` indirection erases the type in generic positions, so TypeScript can no longer prove the result satisfies the `FieldsRecord` constraint (`Type 'unknown' is not assignable to type 'FieldsRecord'`). A local `type Simplify<T> = { readonly [K in keyof T]: T[K] } & {}` keeps the constraint intact.

## Before / after

Hovering a 3-field builder (output captured from the TypeScript compiler, not hand-written):

Before:

```ts
FormBuilder<{ readonly email: FieldDef<"email", String>; } & { readonly password: FieldDef<"password", String>; } & { readonly age: FieldDef<"age", Number>; }, never>
```

After:

```ts
FormBuilder<{ readonly email: FieldDef<"email", String>; readonly password: FieldDef<"password", String>; readonly age: FieldDef<"age", Number>; }, never>
```

## Tests

Added `packages/form/test/FormBuilder.types.test.ts` (vitest `expectTypeOf`, enforced by `check:types` since the test tsconfig is part of the root project build):

- `EncodedFromFields` of a 3-field builder is exactly the expected flat object type
- the builder's `TFields` parameter is mutually assignable with (and equal to) the flat record form
- `merge` produces the flattened union of both builders' fields

`pnpm vitest run` (304 tests), `pnpm check:types`, and `pnpm lint` all green.