### PR TITLE
fix: declare rootError on BuiltForm in react and solid bindings

### DIFF
--- a/.changeset/rooterror-built-form.md
+++ b/.changeset/rooterror-built-form.md
@@ -1,0 +1,6 @@
+---
+"@lucas-barake/effect-form-react": patch
+"@lucas-barake/effect-form-solid": patch
+---
+
+declare `rootError` on `BuiltForm` in the react and solid bindings

--- a/packages/form-react/src/FormReact.tsx
+++ b/packages/form-react/src/FormReact.tsx
@@ -61,6 +61,7 @@ export type BuiltForm<
   readonly lastSubmittedValues: Atom.Atom<Option.Option<FormBuilder.SubmittedValues<TFields>>>
   readonly submitCount: Atom.Atom<number>
   readonly validationCount: Atom.Atom<number>
+  readonly rootError: Atom.Atom<Option.Option<string>>
 
   readonly schema: Schema.Codec<Field.DecodedFromFields<TFields>, Field.EncodedFromFields<TFields>, R>
   readonly fields: FieldRefs<TFields>

--- a/packages/form-react/test/FormReact.test.tsx
+++ b/packages/form-react/test/FormReact.test.tsx
@@ -3605,4 +3605,46 @@ describe("FormReact.make", () => {
       expect(screen.queryByTestId("email-error")).not.toBeInTheDocument()
     })
   })
+
+  describe("rootError atom", () => {
+    it("exposes root-level refinement errors through form.rootError", async () => {
+      const user = userEvent.setup()
+
+      const NameField = Field.makeField("name", Schema.String)
+      const formBuilder = FormBuilder.empty.addField(NameField)
+        .refine((values) => {
+          if (values.name === "invalid") {
+            return "Form-level validation failed"
+          }
+        })
+
+      const form = FormReact.make(formBuilder, {
+        fields: { name: TextInput },
+        onSubmit: () => {}
+      })
+
+      expectTypeOf(form.rootError).toEqualTypeOf<Atom.Atom<Option.Option<string>>>()
+
+      const RootError = () => {
+        const rootError = useAtomValue(form.rootError)
+        return Option.isSome(rootError) ? <span data-testid="root-error">{rootError.value}</span> : null
+      }
+
+      const SubmitButton = makeSubmitButton(form.submit, undefined)
+
+      render(
+        <form.Initialize defaultValues={{ name: "invalid" }}>
+          <form.name />
+          <RootError />
+          <SubmitButton />
+        </form.Initialize>
+      )
+
+      await user.click(screen.getByTestId("submit"))
+
+      await waitFor(() => {
+        expect(screen.getByTestId("root-error")).toHaveTextContent("Form-level validation failed")
+      })
+    })
+  })
 })

--- a/packages/form-solid/src/FormSolid.tsx
+++ b/packages/form-solid/src/FormSolid.tsx
@@ -63,6 +63,7 @@ export type BuiltForm<
   readonly lastSubmittedValues: Atom.Atom<Option.Option<FormBuilder.SubmittedValues<TFields>>>
   readonly submitCount: Atom.Atom<number>
   readonly validationCount: Atom.Atom<number>
+  readonly rootError: Atom.Atom<Option.Option<string>>
 
   readonly schema: Schema.Codec<Field.DecodedFromFields<TFields>, Field.EncodedFromFields<TFields>, R>
   readonly fields: FieldRefs<TFields>

--- a/packages/form-solid/test/FormSolid.test.tsx
+++ b/packages/form-solid/test/FormSolid.test.tsx
@@ -255,4 +255,48 @@ describe("FormSolid.make", () => {
       expect(submitHandler).toHaveBeenCalledWith({ name: "John", age: 42 })
     })
   })
+
+  describe("rootError atom", () => {
+    it("exposes root-level refinement errors through form.rootError", async () => {
+      const user = userEvent.setup()
+
+      const NameField = Field.makeField("name", Schema.String)
+      const formBuilder = FormBuilder.empty.addField(NameField)
+        .refine((values) => {
+          if (values.name === "invalid") {
+            return "Form-level validation failed"
+          }
+        })
+
+      const form = FormSolid.make(formBuilder, {
+        fields: { name: TextInput },
+        onSubmit: () => {}
+      })
+
+      let rootError: Option.Option<string> = Option.none()
+
+      const TestComponent = () => {
+        useAtomSubscribe(() => form.rootError, (error) => {
+          rootError = error
+        }, { immediate: true })
+        return null
+      }
+
+      const SubmitButton = makeSubmitButton(form.submit, undefined)
+
+      render(() => (
+        <form.Initialize defaultValues={{ name: "invalid" }}>
+          <form.name />
+          <TestComponent />
+          <SubmitButton />
+        </form.Initialize>
+      ))
+
+      await user.click(screen.getByTestId("submit"))
+
+      await waitFor(() => {
+        expect(Option.getOrNull(rootError)).toBe("Form-level validation failed")
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Summary

`FormAtoms.make` builds a `rootErrorAtom` (root-level validation error from cross-field refinements without a path, `Atom.Atom<Option.Option<string>>`). Both framework bindings return it at runtime as `rootError`, and the README documents `form.rootError` — but the `BuiltForm` type in both `@lucas-barake/effect-form-react` and `@lucas-barake/effect-form-solid` omitted the property, so `form.rootError` was a compile error for consumers despite existing at runtime.

## Fix

Adds the missing declaration to `BuiltForm` in both bindings, matching the sibling atom declarations:

```ts
readonly rootError: Atom.Atom<Option.Option<string>>
```

## Red → Green

- **Red:** added regression tests in `packages/form-react/test/FormReact.test.tsx` and `packages/form-solid/test/FormSolid.test.tsx` that access `form.rootError` in typed code (no casts) and assert at runtime that a path-less refinement error (`.refine` returning a message string) surfaces through it after submit. Before the fix, `pnpm check:types` failed with `TS2339: Property 'rootError' does not exist on type 'BuiltForm<...>'` in both test files, while the runtime assertions already passed (the property exists at runtime).
- **Green:** with the one-line type additions, `pnpm check:types` passes.

## Test results

- `pnpm check:types` — clean
- `pnpm vitest run` — 9 files, 303 tests, all passing (includes the 2 new regression tests)
- `pnpm lint` — clean