### PR TITLE
fix: descriptive errors when form atoms are used before initialization

### DIFF
--- a/.changeset/descriptive-uninit-errors.md
+++ b/.changeset/descriptive-uninit-errors.md
@@ -1,0 +1,7 @@
+---
+"@lucas-barake/effect-form": patch
+"@lucas-barake/effect-form-react": patch
+"@lucas-barake/effect-form-solid": patch
+---
+
+descriptive errors when form atoms are used before initialization

--- a/packages/form-react/src/FormReact.tsx
+++ b/packages/form-react/src/FormReact.tsx
@@ -188,9 +188,17 @@ const makeArrayFieldComponent = <S extends Schema.Top,>(
   }> = ({ children }) => {
     const arrayCtx = useContext(ArrayItemContext)
     const [formStateOption, setFormState] = useAtom(stateAtom)
-    const formState = Option.getOrThrow(formStateOption)
 
     const fieldPath = arrayCtx ? `${arrayCtx.parentPath}.${fieldKey}` : fieldKey
+    if (Option.isNone(formStateOption)) {
+      throw new Error(
+        `Array field "${fieldPath}" was rendered before the form was initialized. ` +
+          "Form state does not exist until initialization: render array field components inside " +
+          "<form.Initialize defaultValues={...}>. " +
+          `See the "Basic Form Setup" section of the README.`
+      )
+    }
+    const formState = formStateOption.value
     const items = React.useMemo(
       () => (getNestedValue(formState.values, fieldPath) ?? []) as ReadonlyArray<Schema.Codec.Encoded<S>>,
       [formState.values, fieldPath]

--- a/packages/form-react/test/FormReact.test.tsx
+++ b/packages/form-react/test/FormReact.test.tsx
@@ -343,6 +343,44 @@ describe("FormReact.make", () => {
       })
     })
 
+    it("throws a descriptive error when array field renders outside Initialize", () => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+      const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+      const formBuilder = FormBuilder.empty.addField(ItemsArrayField)
+
+      const ItemNameInput: FormReact.FieldComponent<string> = ({ field }) => (
+        <input
+          type="text"
+          value={field.value}
+          onChange={(e) => field.onChange(e.target.value)}
+          data-testid="item-name"
+        />
+      )
+
+      const form = FormReact.make(formBuilder, {
+        fields: { items: { name: ItemNameInput } },
+        onSubmit: () => {}
+      })
+
+      expect(() =>
+        render(
+          <form.items>
+            {() => null}
+          </form.items>
+        )
+      ).toThrowError(`Array field "items" was rendered before the form was initialized`)
+      expect(() =>
+        render(
+          <form.items>
+            {() => null}
+          </form.items>
+        )
+      ).toThrowError(/<form\.Initialize/)
+
+      consoleError.mockRestore()
+    })
+
     it("renders array item subfields when item schema uses filterEffect", async () => {
       const user = userEvent.setup()
 

--- a/packages/form-solid/src/FormSolid.tsx
+++ b/packages/form-solid/src/FormSolid.tsx
@@ -188,9 +188,20 @@ const makeArrayFieldComponent = <S extends Schema.Top,>(
   }> = (props) => {
     const arrayCtx = useContext(ArrayItemContext)
     const [formStateOption, setFormState] = useAtom(() => stateAtom)
-    const formState = createMemo(() => Option.getOrThrow(formStateOption()))
 
     const fieldPath = arrayCtx ? `${arrayCtx.parentPath}.${fieldKey}` : fieldKey
+    const formState = createMemo(() => {
+      const stateOption = formStateOption()
+      if (Option.isNone(stateOption)) {
+        throw new Error(
+          `Array field "${fieldPath}" was rendered before the form was initialized. ` +
+            "Form state does not exist until initialization: render array field components inside " +
+            "<form.Initialize defaultValues={...}>. " +
+            `See the "Basic Form Setup" section of the README.`
+        )
+      }
+      return stateOption.value
+    })
     const items = createMemo(
       () => (getNestedValue(formState().values, fieldPath) ?? []) as ReadonlyArray<Schema.Codec.Encoded<S>>
     )

--- a/packages/form-solid/test/FormSolid.test.tsx
+++ b/packages/form-solid/test/FormSolid.test.tsx
@@ -216,6 +216,42 @@ describe("FormSolid.make", () => {
     })
   })
 
+  describe("array fields", () => {
+    it("throws a descriptive error when array field renders outside Initialize", () => {
+      const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+      const formBuilder = FormBuilder.empty.addField(ItemsArrayField)
+
+      const ItemNameInput: FormSolid.FieldComponent<string> = ({ field }) => (
+        <input
+          type="text"
+          value={field().value}
+          onInput={(e) => field().onChange(e.currentTarget.value)}
+          data-testid="item-name"
+        />
+      )
+
+      const form = FormSolid.make(formBuilder, {
+        fields: { items: { name: ItemNameInput } },
+        onSubmit: () => {}
+      })
+
+      expect(() =>
+        render(() => (
+          <form.items>
+            {() => null}
+          </form.items>
+        ))
+      ).toThrowError(`Array field "items" was rendered before the form was initialized`)
+      expect(() =>
+        render(() => (
+          <form.items>
+            {() => null}
+          </form.items>
+        ))
+      ).toThrowError(/<form\.Initialize/)
+    })
+  })
+
   it("submit calls onSubmit with decoded values", async () => {
     const user = userEvent.setup()
     const submitHandler = vi.fn()

--- a/packages/form/src/FormAtoms.ts
+++ b/packages/form/src/FormAtoms.ts
@@ -182,6 +182,21 @@ export interface FormOperations<TFields extends Field.FieldsRecord,> {
   readonly revertToLastSubmit: (state: FormBuilder.FormState<TFields>) => FormBuilder.FormState<TFields>
 }
 
+const getStateOrThrow = <TFields extends Field.FieldsRecord,>(
+  state: Option.Option<FormBuilder.FormState<TFields>>,
+  fieldPath: string
+): FormBuilder.FormState<TFields> => {
+  if (Option.isNone(state)) {
+    throw new Error(
+      `Field "${fieldPath}" was read before the form was initialized. ` +
+        "Form state does not exist until initialization: render your fields inside " +
+        "<form.Initialize defaultValues={...}> (React/Solid), or set the form state before reading field atoms. " +
+        `See the "Basic Form Setup" section of the README.`
+    )
+  }
+  return state.value
+}
+
 export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = void,>(
   config: FormAtomsConfig<TFields, R, A, E, SubmitArgs>
 ): FormAtoms<TFields, R, A, E, SubmitArgs> => {
@@ -299,21 +314,21 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
     if (existing && existingSchema === schema) return existing
 
     const valueAtom = Atom.writable(
-      (get) => getNestedValue(Option.getOrThrow(get(stateAtom)).values, fieldPath),
+      (get) => getNestedValue(getStateOrThrow(get(stateAtom), fieldPath).values, fieldPath),
       (ctx, value) => {
-        const currentState = Option.getOrThrow(ctx.get(stateAtom))
+        const currentState = getStateOrThrow(ctx.get(stateAtom), fieldPath)
         ctx.set(stateAtom, Option.some(operations.setFieldValue(currentState, fieldPath, value)))
       }
     ).pipe(Atom.setIdleTTL(0))
 
     const initialValueAtom = Atom.readable((get) =>
-      getNestedValue(Option.getOrThrow(get(stateAtom)).initialValues, fieldPath)
+      getNestedValue(getStateOrThrow(get(stateAtom), fieldPath).initialValues, fieldPath)
     ).pipe(Atom.setIdleTTL(0))
 
     const touchedAtom = Atom.writable(
-      (get) => (getNestedValue(Option.getOrThrow(get(stateAtom)).touched, fieldPath) ?? false) as boolean,
+      (get) => (getNestedValue(getStateOrThrow(get(stateAtom), fieldPath).touched, fieldPath) ?? false) as boolean,
       (ctx, value) => {
-        const currentState = Option.getOrThrow(ctx.get(stateAtom))
+        const currentState = getStateOrThrow(ctx.get(stateAtom), fieldPath)
         ctx.set(
           stateAtom,
           Option.some({
@@ -465,7 +480,15 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
       (args, get) =>
         Effect.gen(function*() {
           const state = get(stateAtom)
-          if (Option.isNone(state)) return yield* Effect.die("Form not initialized")
+          if (Option.isNone(state)) {
+            return yield* Effect.die(
+              new Error(
+                "submit was called before the form was initialized — mount " +
+                  "<form.Initialize defaultValues={...}> before submitting. " +
+                  `See the "Basic Form Setup" section of the README.`
+              )
+            )
+          }
           const values = state.value.values
           get.set(errorsAtom, new Map())
           const decoded = yield* pipe(

--- a/packages/form/test/FormAtoms.test.ts
+++ b/packages/form/test/FormAtoms.test.ts
@@ -1,3 +1,4 @@
+import * as Cause from "effect/Cause"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
@@ -654,6 +655,98 @@ describe("FormAtoms", () => {
       expect(fieldAtomsA).not.toBe(fieldAtomsB)
       expect(fieldAtomsA.validationAtom).not.toBe(fieldAtomsB.validationAtom)
       expect(atoms.validationAtomsRegistry.get("name")).toBe(fieldAtomsB.validationAtom)
+    })
+  })
+
+  describe("uninitialized form access", () => {
+    it("valueAtom read throws a descriptive error naming the field and Initialize", () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const form = makeTestForm()
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit: () => {} })
+      const registry = AtomRegistry.make()
+
+      const fieldAtoms = atoms.getOrCreateFieldAtoms("name", Schema.String)
+
+      expect(() => registry.get(fieldAtoms.valueAtom)).toThrowError(
+        `Field "name" was read before the form was initialized`
+      )
+      expect(() => registry.get(fieldAtoms.valueAtom)).toThrowError(/<form\.Initialize/)
+    })
+
+    it("valueAtom write throws a descriptive error naming the field and Initialize", () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const form = makeTestForm()
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit: () => {} })
+      const registry = AtomRegistry.make()
+
+      const fieldAtoms = atoms.getOrCreateFieldAtoms("name", Schema.String)
+
+      expect(() => registry.set(fieldAtoms.valueAtom, "Jane")).toThrowError(
+        `Field "name" was read before the form was initialized`
+      )
+      expect(() => registry.set(fieldAtoms.valueAtom, "Jane")).toThrowError(/<form\.Initialize/)
+    })
+
+    it("initialValueAtom read throws a descriptive error naming the field and Initialize", () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const form = makeTestForm()
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit: () => {} })
+      const registry = AtomRegistry.make()
+
+      const fieldAtoms = atoms.getOrCreateFieldAtoms("email", Schema.String)
+
+      expect(() => registry.get(fieldAtoms.initialValueAtom)).toThrowError(
+        `Field "email" was read before the form was initialized`
+      )
+      expect(() => registry.get(fieldAtoms.initialValueAtom)).toThrowError(/<form\.Initialize/)
+    })
+
+    it("touchedAtom read and write throw a descriptive error naming the field and Initialize", () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const form = makeTestForm()
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit: () => {} })
+      const registry = AtomRegistry.make()
+
+      const fieldAtoms = atoms.getOrCreateFieldAtoms("name", Schema.String)
+
+      expect(() => registry.get(fieldAtoms.touchedAtom)).toThrowError(
+        `Field "name" was read before the form was initialized`
+      )
+      expect(() => registry.set(fieldAtoms.touchedAtom, true)).toThrowError(/<form\.Initialize/)
+    })
+
+    it("includes the full nested field path in the error message", () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const form = makeArrayTestForm()
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit: () => {} })
+      const registry = AtomRegistry.make()
+
+      const fieldAtoms = atoms.getOrCreateFieldAtoms("items[0].name", Schema.String)
+
+      expect(() => registry.get(fieldAtoms.valueAtom)).toThrowError(
+        `Field "items[0].name" was read before the form was initialized`
+      )
+    })
+
+    it("submitAtom fails with a descriptive defect when submitted before initialization", async () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const form = makeTestForm()
+      const onSubmit = vi.fn()
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit })
+      const registry = AtomRegistry.make()
+
+      registry.mount(atoms.submitAtom)
+      registry.set(atoms.submitAtom, undefined)
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      expect(onSubmit).not.toHaveBeenCalled()
+      const result = registry.get(atoms.submitAtom)
+      expect(result._tag).toBe("Failure")
+      const defect = result._tag === "Failure" ? Cause.squash(result.cause) : undefined
+      expect(defect).toBeInstanceOf(Error)
+      expect((defect as Error).message).toContain("submit was called before the form was initialized")
+      expect((defect as Error).message).toContain("<form.Initialize")
     })
   })
 


### PR DESCRIPTION
## Problem

Using form atoms before the form is initialized (i.e. before `<form.Initialize>` mounts and sets `stateAtom`) is the first wall a new user hits, and the errors gave zero context:

- Reading/writing `valueAtom`, `initialValueAtom`, or `touchedAtom` threw a bare `getOrThrow called on a None`
- Submitting threw a bare string defect: `Form not initialized`
- Rendering an array field component outside `<form.Initialize>` (React and Solid) also threw `getOrThrow called on a None`

None of these named the offending field or said how to fix it.

## Before / After

Reading a field atom before initialization:

```
// Before
NoSuchElementError: getOrThrow called on a None

// After
Error: Field "items[0].name" was read before the form was initialized. Form state does not exist until initialization: render your fields inside <form.Initialize defaultValues={...}> (React/Solid), or set the form state before reading field atoms. See the "Basic Form Setup" section of the README.
```

Submitting before initialization:

```
// Before (defect)
"Form not initialized"

// After (defect)
Error: submit was called before the form was initialized — mount <form.Initialize defaultValues={...}> before submitting. See the "Basic Form Setup" section of the README.
```

Rendering an array field outside `<form.Initialize>` (React and Solid bindings):

```
// Before
NoSuchElementError: getOrThrow called on a None

// After
Error: Array field "items" was rendered before the form was initialized. Form state does not exist until initialization: render array field components inside <form.Initialize defaultValues={...}>. See the "Basic Form Setup" section of the README.
```

## Changes

- `packages/form/src/FormAtoms.ts`: new internal `getStateOrThrow(state, fieldPath)` helper replaces the five bare `Option.getOrThrow(get(stateAtom))` calls in `valueAtom` (read + write), `initialValueAtom`, and `touchedAtom` (read + write); `submitAtom` now dies with a descriptive `Error` instead of a bare string (`Effect.dieMessage` does not exist in this effect version, so `Effect.die(new Error(...))` is used)
- `packages/form-react/src/FormReact.tsx` / `packages/form-solid/src/FormSolid.tsx`: `ArrayWrapper` now throws a descriptive error naming the full field path instead of `Option.getOrThrow(formStateOption)`
- Sites that intentionally no-op on `None` (`resetAtom`, `setValuesAtom`, `validateAtom`, etc.) are left unchanged

## Tests

8 new tests (written red first against the old bare errors, then made green):

- `packages/form/test/FormAtoms.test.ts` (6): value/initialValue/touched atom reads and writes throw errors matching the field path and `<form.Initialize`, including nested array paths (`items[0].name`); uninitialized submit fails with the descriptive defect
- `packages/form-react/test/FormReact.test.tsx` (1) and `packages/form-solid/test/FormSolid.test.tsx` (1): rendering an array field outside `<form.Initialize>` throws the descriptive error

Full suite: 309 tests passing (`pnpm vitest run`), `pnpm check:types` and `pnpm lint` clean.
