### PR TITLE
fix: Solid array item inputs lose focus and drop input after one keystroke

### DIFF
--- a/.changeset/solid-array-tracking.md
+++ b/.changeset/solid-array-tracking.md
@@ -1,0 +1,5 @@
+---
+"@lucas-barake/effect-form-solid": patch
+---
+
+fix array item inputs losing focus and dropping input after one keystroke

--- a/packages/form-solid/src/FormSolid.tsx
+++ b/packages/form-solid/src/FormSolid.tsx
@@ -10,7 +10,7 @@ import type * as Schema from "effect/Schema"
 import * as Atom from "effect/unstable/reactivity/Atom"
 import type * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
 import type { Accessor, Component, JSX } from "solid-js"
-import { createContext, createMemo, createSignal, onCleanup, onMount, Show, useContext } from "solid-js"
+import { createContext, createMemo, createSignal, onCleanup, onMount, Show, untrack, useContext } from "solid-js"
 
 export type FieldValue<T,> = FieldStateModule.FieldValue<T>
 
@@ -223,7 +223,17 @@ const makeArrayFieldComponent = <S extends Schema.Top,>(
       })
     }
 
-    return <>{props.children({ items: items(), append, remove, swap, move })}</>
+    const ops: ArrayFieldOperations<Schema.Codec.Encoded<S>> = {
+      get items() {
+        return items()
+      },
+      append,
+      remove,
+      swap,
+      move
+    }
+
+    return <>{untrack(() => props.children(ops))}</>
   }
 
   const ItemWrapper: Component<{

--- a/packages/form-solid/test/FormSolidArrayField.test.tsx
+++ b/packages/form-solid/test/FormSolidArrayField.test.tsx
@@ -1,0 +1,133 @@
+import { Field, FormBuilder, FormSolid } from "@lucas-barake/effect-form-solid"
+import { render, screen, waitFor } from "@solidjs/testing-library"
+import { userEvent } from "@testing-library/user-event"
+import * as Schema from "effect/Schema"
+import { Index } from "solid-js"
+import { describe, expect, it } from "vitest"
+
+const ItemNameInput: FormSolid.FieldComponent<string> = ({ field }) => (
+  <input
+    type="text"
+    value={field().value}
+    onInput={(e) => field().onChange(e.currentTarget.value)}
+    onBlur={field().onBlur}
+    data-testid="item-name"
+  />
+)
+
+describe("FormSolid array field reactivity", () => {
+  it("remove removes middle item (Index)", async () => {
+    const user = userEvent.setup()
+    const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+    const formBuilder = FormBuilder.empty.addField(ItemsArrayField)
+
+    const form = FormSolid.make(formBuilder, {
+      fields: { items: { name: ItemNameInput } },
+      onSubmit: () => {}
+    })
+
+    render(() => (
+      <form.Initialize defaultValues={{ items: [{ name: "A" }, { name: "B" }, { name: "C" }] }}>
+        <form.items>
+          {(ops) => (
+            <Index each={ops.items}>
+              {(_item, i) => (
+                <div>
+                  <form.items.Item index={i}>
+                    <form.items.name />
+                  </form.items.Item>
+                  <button type="button" onClick={() => ops.remove(i)} data-testid={`remove-${i}`}>
+                    Remove
+                  </button>
+                </div>
+              )}
+            </Index>
+          )}
+        </form.items>
+      </form.Initialize>
+    ))
+
+    let inputs = screen.getAllByTestId("item-name") as Array<HTMLInputElement>
+    expect(inputs.map((i) => i.value)).toEqual(["A", "B", "C"])
+
+    await user.click(screen.getByTestId("remove-1"))
+
+    await waitFor(() => {
+      const updated = screen.getAllByTestId("item-name") as Array<HTMLInputElement>
+      expect(updated).toHaveLength(2)
+      expect(updated.map((i) => i.value)).toEqual(["A", "C"])
+    })
+  })
+
+  it("typing multiple chars into an array item field preserves them (Index)", async () => {
+    const user = userEvent.setup()
+    const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+    const formBuilder = FormBuilder.empty.addField(ItemsArrayField)
+
+    const form = FormSolid.make(formBuilder, {
+      fields: { items: { name: ItemNameInput } },
+      onSubmit: () => {}
+    })
+
+    render(() => (
+      <form.Initialize defaultValues={{ items: [{ name: "" }] }}>
+        <form.items>
+          {(ops) => (
+            <Index each={ops.items}>
+              {(_item, i) => (
+                <form.items.Item index={i}>
+                  <form.items.name />
+                </form.items.Item>
+              )}
+            </Index>
+          )}
+        </form.items>
+      </form.Initialize>
+    ))
+
+    const input = screen.getByTestId("item-name") as HTMLInputElement
+    await user.type(input, "Hello")
+
+    await waitFor(() => {
+      expect((screen.getByTestId("item-name") as HTMLInputElement).value).toBe("Hello")
+    })
+  })
+
+  it("append adds a row (Index)", async () => {
+    const user = userEvent.setup()
+    const ItemsArrayField = Field.makeArrayField("items", Schema.Struct({ name: Schema.String }))
+    const formBuilder = FormBuilder.empty.addField(ItemsArrayField)
+
+    const form = FormSolid.make(formBuilder, {
+      fields: { items: { name: ItemNameInput } },
+      onSubmit: () => {}
+    })
+
+    render(() => (
+      <form.Initialize defaultValues={{ items: [{ name: "Item 1" }] }}>
+        <form.items>
+          {(ops) => (
+            <>
+              <Index each={ops.items}>
+                {(_item, i) => (
+                  <form.items.Item index={i}>
+                    <form.items.name />
+                  </form.items.Item>
+                )}
+              </Index>
+              <button type="button" onClick={() => ops.append()} data-testid="add">
+                Add
+              </button>
+            </>
+          )}
+        </form.items>
+      </form.Initialize>
+    ))
+
+    expect(screen.getAllByTestId("item-name")).toHaveLength(1)
+    await user.click(screen.getByTestId("add"))
+    await waitFor(() => {
+      expect(screen.getAllByTestId("item-name")).toHaveLength(2)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Critical Solid-binding bug found in a deep review: **you can only type one character into any array item field**.

`ArrayWrapper` called `props.children({ items: items(), ... })` with the `items()` memo read inside the tracked JSX expression. Form state is immutable, so every keystroke produces a new array reference, invalidating the tracked expression — Solid tears down and recreates the entire item subtree, destroying the active `<input>`. Typing `Hello` leaves the field containing `H`.

## Fix

Expose `items` as a lazy getter on the ops object and invoke the render prop once, `untrack`ed, so `<Index>`/`<For>` handle reactivity granularly instead of the whole subtree re-running.

## Tests

New `FormSolidArrayField.test.tsx`: the typing regression (Red: `expected 'H' to be 'Hello'` before the fix, Green after) plus append/remove tests that pass both before and after, proving the `untrack` does not regress add/remove reactivity. Full suite: 304 passed, types + lint clean.

Found by: sharded deep review with mandatory executed Red→Green validation; independently re-validated (Red re-confirmed on clean main, Green after patch).