### PR TITLE
fix: auto-submit silently drops a change made during a follow-up submit

### DIFF
--- a/.changeset/autosubmit-lost-change.md
+++ b/.changeset/autosubmit-lost-change.md
@@ -1,0 +1,5 @@
+---
+"@lucas-barake/effect-form": patch
+---
+
+fix auto-submit silently dropping a change made during a follow-up submit

--- a/packages/form/src/FormAtoms.ts
+++ b/packages/form/src/FormAtoms.ts
@@ -883,13 +883,16 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
       get.subscribe(submitAtom, () => {
         const result = get.once(submitAtom)
         const isSubmitting = result.waiting
-        if (wasSubmitting && !isSubmitting) {
-          if (pendingChanges) {
-            pendingChanges = false
-            debouncedSubmit()
-          }
-        }
+        const justFinished = wasSubmitting && !isSubmitting
+        // Update wasSubmitting BEFORE triggering a follow-up submit. debouncedSubmit
+        // (no debounce) synchronously re-enters this subscription with the new
+        // waiting=true state; if we assigned wasSubmitting afterwards we'd clobber
+        // that re-entrant true with the stale false, losing the next change.
         wasSubmitting = isSubmitting
+        if (justFinished && pendingChanges) {
+          pendingChanges = false
+          debouncedSubmit()
+        }
       })
     }).pipe(Atom.setIdleTTL(0))
     : Atom.readable(() => {}).pipe(Atom.setIdleTTL(0))

--- a/packages/form/test/FormAtoms.test.ts
+++ b/packages/form/test/FormAtoms.test.ts
@@ -2207,6 +2207,60 @@ describe("FormAtoms", () => {
       expect(completions).toHaveBeenCalledTimes(1)
     })
 
+    it("does not lose a change made during a follow-up auto-submit (no debounce)", async () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const form = makeTestForm()
+
+      const submittedNames: Array<string> = []
+      const resolvers: Array<() => void> = []
+      const onSubmit = vi.fn((_args: void, ctx: { readonly encoded: { readonly name: string } }) =>
+        Effect.callback<void, never>((resume) => {
+          submittedNames.push(ctx.encoded.name)
+          resolvers.push(() => resume(Effect.void))
+        })
+      )
+
+      const atoms = FormAtoms.make({
+        runtime,
+        formBuilder: form,
+        onSubmit,
+        // no debounce -> follow-up submit fires synchronously on completion
+        mode: { validation: "onChange", autoSubmit: true }
+      })
+      const registry = AtomRegistry.make()
+
+      const state0 = atoms.operations.createInitialState({ name: "a", email: "e@e.com" })
+      registry.set(atoms.stateAtom, Option.some(state0))
+      registry.mount(atoms.autoSubmitAtom)
+      registry.mount(atoms.submitAtom)
+      registry.mount(atoms.stateAtom)
+
+      // change -> submit A ("b")
+      const stateB = atoms.operations.setFieldValue(state0, "name", "b")
+      registry.set(atoms.stateAtom, Option.some(stateB))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(submittedNames).toEqual(["b"])
+
+      // change during in-flight submit A -> queued as pendingChanges
+      const stateC = atoms.operations.setFieldValue(stateB, "name", "c")
+      registry.set(atoms.stateAtom, Option.some(stateC))
+
+      // complete submit A -> follow-up submit B ("c")
+      resolvers[0]()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(submittedNames).toEqual(["b", "c"])
+
+      // change during in-flight submit B -> must be queued as pendingChanges
+      const stateD = atoms.operations.setFieldValue(stateC, "name", "d")
+      registry.set(atoms.stateAtom, Option.some(stateD))
+
+      // complete submit B -> follow-up submit C ("d") must fire
+      resolvers[1]()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(submittedNames).toEqual(["b", "c", "d"])
+    })
+
     it("does not trigger submit when values have not changed", async () => {
       const runtime = Atom.runtime(Layer.empty)
       const form = makeTestForm()


### PR DESCRIPTION
## Summary

High-severity lost-update in `autoSubmitAtom` (onChange + autoSubmit, no debounce), found in a deep review with executed Red→Green validation.

When a submit completes with `pendingChanges` queued, the follow-up `get.set(submitAtom)` runs synchronously and the batch commit re-enters the `submitAtom` subscription in place. The re-entrant invocation correctly sets `wasSubmitting = true`, but control then returns to the outer callback whose trailing `wasSubmitting = isSubmitting` still holds the stale `false` — clobbering it. From then on the tracker believes no submit is in flight, so when the follow-up submit completes, the `wasSubmitting && !isSubmitting` guard fails and any change queued during it is **silently never submitted** (stale server state).

Interleaving: submit A in flight → edit "c" queued → A completes → follow-up B("c") fires and corrupts the flag → edit "d" queued during B → B completes → guard false → **"d" never submits**.

Re-entry mechanics verified in the installed effect source (batch write/refresh: Atom.ts:1244-1253; synchronous listener notify in commit: AtomRegistry.ts:1069-1073).

## Fix

Assign `wasSubmitting` before triggering the follow-up submit, so the re-entrant `waiting=true` assignment is the last write.

## Tests

New regression test drives the exact interleaving with gated `Effect.callback` submits: Red on unmodified code (`expected [ 'b', 'c' ] to deeply equal [ 'b', 'c', 'd' ]`), Green after. Full suite 302 passed, types + lint clean. Independently re-validated (Red re-confirmed on clean main before applying the fix).