### PR TITLE
fix: failed onSubmit is recorded as a successful submit

### DIFF
--- a/.changeset/failed-submit-not-recorded.md
+++ b/.changeset/failed-submit-not-recorded.md
@@ -1,0 +1,5 @@
+---
+"@lucas-barake/effect-form": patch
+---
+
+a failed `onSubmit` is no longer recorded as a successful submit (`lastSubmittedValues` only updates when `onSubmit` succeeds)

--- a/packages/form/src/FormAtoms.ts
+++ b/packages/form/src/FormAtoms.ts
@@ -483,18 +483,26 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
             )
           )
           const submitState = operations.createSubmitState(state.value)
-          get.set(
-            stateAtom,
-            Option.some({
-              ...submitState,
-              lastSubmittedValues: Option.some({ encoded: values, decoded })
-            })
-          )
+          get.set(stateAtom, Option.some(submitState))
           const result = config.onSubmit(args, { decoded, encoded: values, get })
-          if (Effect.isEffect(result)) {
-            return yield* result as Effect.Effect<A, E, R>
+          const output = Effect.isEffect(result)
+            ? yield* (result as Effect.Effect<A, E, R>)
+            : (result as A)
+          // Only record the values as "last submitted" once onSubmit has
+          // succeeded. A failed onSubmit must not be reported as a successful
+          // submit, otherwise revertToLastSubmit / hasChangedSinceSubmit would
+          // treat unsaved, failed values as persisted.
+          const afterSubmit = get(stateAtom)
+          if (Option.isSome(afterSubmit)) {
+            get.set(
+              stateAtom,
+              Option.some({
+                ...afterSubmit.value,
+                lastSubmittedValues: Option.some({ encoded: values, decoded })
+              })
+            )
           }
-          return result as A
+          return output
         }),
       config.reactivityKeys ? { reactivityKeys: config.reactivityKeys } : undefined
     )

--- a/packages/form/test/FormAtoms.test.ts
+++ b/packages/form/test/FormAtoms.test.ts
@@ -1598,6 +1598,34 @@ describe("FormAtoms", () => {
       expect(Option.isSome(finalState.lastSubmittedValues)).toBe(true)
       expect(Option.getOrThrow(finalState.lastSubmittedValues).encoded.email).toBe("first@example.com")
     })
+
+    it("does not record lastSubmittedValues when onSubmit itself fails", async () => {
+      const runtime = Atom.runtime(Layer.empty)
+      const EmailField = Field.makeField(
+        "email",
+        Schema.String.pipe(Schema.check(Schema.isNonEmpty({ message: "Email is required" })))
+      )
+      const form = FormBuilder.empty.addField(EmailField)
+      const onSubmit = vi.fn(() => Effect.fail("network error"))
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit })
+      const registry = AtomRegistry.make()
+
+      const initialState = atoms.operations.createInitialState({ email: "valid@example.com" })
+      registry.set(atoms.stateAtom, Option.some(initialState))
+      registry.mount(atoms.stateAtom)
+      registry.mount(atoms.lastSubmittedValuesAtom)
+      registry.mount(atoms.submitAtom)
+      registry.set(atoms.submitAtom, undefined)
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // onSubmit ran (validation passed) but FAILED. The submit did not succeed,
+      // so the form must not report these values as "last submitted".
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      const stateAfter = registry.get(atoms.stateAtom).pipe(Option.getOrThrow)
+      expect(Option.isNone(stateAfter.lastSubmittedValues)).toBe(true)
+      expect(Option.isNone(registry.get(atoms.lastSubmittedValuesAtom))).toBe(true)
+    })
   })
 
   describe("rootErrorAtom", () => {


### PR DESCRIPTION
## Summary

High-severity data-integrity bug found in a deep review with executed Red→Green validation: `submitAtom` wrote `lastSubmittedValues` **before** invoking `onSubmit`. When the submit effect fails (e.g. the network save rejects), the form still records those values as the last-submitted snapshot, corrupting the change-tracking contract:

- `hasChangedSinceSubmit` turns **false** — the UI tells the user their failed data was saved (silent data loss from the user's perspective)
- `revertToLastSubmit` reverts to values whose submission **failed**, treating them as a good baseline
- onBlur auto-submit skips retrying because values equal the recorded snapshot

This matches the README state-lifecycle table's intent ("Submit → lastSubmittedValues = Some(B)" paired with the unsaved-changes use case): last submitted means last **saved**, not last **attempted**.

## Fix

Run `onSubmit` first; only commit `lastSubmittedValues` after it succeeds (rebased onto the then-current state). `submitCount` and touched still update before `onSubmit` so the attempt is counted and validation errors surface on failure.

**Design note:** if "last attempted" semantics were ever intended instead, this should be closed and the README updated to say so — but every consumer surface (`hasChangedSinceSubmit`, `revertToLastSubmit`, onBlur resubmit) behaves correctly only with "last saved".

## Tests

New regression test: valid values + `onSubmit = Effect.fail("network error")` → asserts `lastSubmittedValues` stays `None`. Red on unmodified code, Green after. Full suite 302 passed, types + lint clean. Independently re-validated (Red re-confirmed on clean main before applying the fix).

**Note:** a follow-up PR fixing a second, distinct defect in the same lines (stale-snapshot writeback clobbering concurrent edits) is stacked on this branch — merge this one first.