### PR TITLE
fix: field edit during an in-flight async submit is silently reverted

### DIFF
--- a/.changeset/submit-stale-writeback.md
+++ b/.changeset/submit-stale-writeback.md
@@ -1,0 +1,5 @@
+---
+"@lucas-barake/effect-form": patch
+---
+
+preserve field edits made during an in-flight async submit instead of reverting to the pre-submit snapshot

--- a/packages/form/src/FormAtoms.ts
+++ b/packages/form/src/FormAtoms.ts
@@ -478,11 +478,19 @@ export const make = <TFields extends Field.FieldsRecord, R, A, E, SubmitArgs = v
               Effect.sync(() => {
                 const routedErrors = Validation.routeErrorsWithSource(parseError)
                 get.set(errorsAtom, routedErrors)
-                get.set(stateAtom, Option.some(operations.createSubmitState(state.value)))
+                // Rebase onto the latest state so edits made during the in-flight
+                // async decode are preserved instead of clobbered by the snapshot.
+                const latest = get(stateAtom)
+                const base = Option.isSome(latest) ? latest.value : state.value
+                get.set(stateAtom, Option.some(operations.createSubmitState(base)))
               })
             )
           )
-          const submitState = operations.createSubmitState(state.value)
+          // Rebase onto the latest state so a field edit made while the async
+          // decode was running is not silently reverted to the pre-submit snapshot.
+          const latestState = get(stateAtom)
+          const baseState = Option.isSome(latestState) ? latestState.value : state.value
+          const submitState = operations.createSubmitState(baseState)
           get.set(stateAtom, Option.some(submitState))
           const result = config.onSubmit(args, { decoded, encoded: values, get })
           const output = Effect.isEffect(result)

--- a/packages/form/test/FormAtoms.test.ts
+++ b/packages/form/test/FormAtoms.test.ts
@@ -1599,6 +1599,48 @@ describe("FormAtoms", () => {
       expect(Option.getOrThrow(finalState.lastSubmittedValues).encoded.email).toBe("first@example.com")
     })
 
+    it("preserves a field edit made during an in-flight async submit", async () => {
+      let releaseDecode: (() => void) | undefined
+      const NameField = Field.makeField(
+        "name",
+        Schema.String.pipe(
+          Schema.decode({
+            decode: SchemaGetter.checkEffect((_v: string) =>
+              Effect.callback<string | undefined, never>((resume) => {
+                releaseDecode = () => resume(Effect.succeed(undefined)) // valid
+              })
+            ),
+            encode: SchemaGetter.passthrough()
+          })
+        )
+      )
+
+      const runtime = Atom.runtime(Layer.empty)
+      const form = FormBuilder.empty.addField(NameField)
+      const atoms = FormAtoms.make({ runtime, formBuilder: form, onSubmit: () => {} })
+      const registry = AtomRegistry.make()
+
+      registry.set(atoms.stateAtom, Option.some(atoms.operations.createInitialState({ name: "V0" })))
+      registry.mount(atoms.stateAtom)
+      registry.mount(atoms.submitAtom)
+
+      // start submit -> async decode is now gated (in-flight)
+      registry.set(atoms.submitAtom, undefined)
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      // user edits the field while the submit's decode is in-flight
+      const cur = Option.getOrThrow(registry.get(atoms.stateAtom))
+      registry.set(atoms.stateAtom, Option.some(atoms.operations.setFieldValue(cur, "name", "V1")))
+
+      // complete the decode -> submit writes its success state
+      releaseDecode?.()
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      const finalValues = Option.getOrThrow(registry.get(atoms.stateAtom)).values
+      // the edit made during submit must not be silently reverted
+      expect(finalValues).toEqual({ name: "V1" })
+    })
+
     it("does not record lastSubmittedValues when onSubmit itself fails", async () => {
       const runtime = Atom.runtime(Layer.empty)
       const EmailField = Field.makeField(


### PR DESCRIPTION
## Summary

**Stacked on #103 — merge that first** (GitHub will retarget this to `main` automatically). Second, distinct defect in the same `submitAtom` lines, found in a deep review with executed Red→Green validation.

`submitAtom` captures `state` at submit start. With async refinements (an explicitly supported case — services in the decode path), the fiber suspends mid-decode. A field edit made during that window updates `stateAtom`, but on completion both writebacks — the `tapError` validation-failure branch and the success branch — call `createSubmitState(state.value)` on the **stale captured snapshot**, clobbering the concurrent edit. The form silently reverts to pre-submit values: typed input vanishes (data loss).

Verified the in-flight submit is NOT restarted by the edit (decode runs exactly once), so the stale write always wins.

## Fix

Rebase both writebacks onto the current `stateAtom` value. The values captured at submit start are still what get decoded and recorded as `lastSubmittedValues.encoded` — only the state the writeback is layered on changes.

## Tests

New regression test gates the decode with `Effect.callback`, edits `name` from V0→V1 mid-flight, releases the decode, and asserts values remain V1. Red on the base branch (`expected { name: 'V0' } to deeply equal { name: 'V1' }`), Green after. Full suite 303 passed, types + lint clean. Independently re-validated on top of #103.