### PR TITLE
chore: point changesets baseBranch at main

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "v4",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []
 }


### PR DESCRIPTION
The v4 branch was promoted to `main` (old main preserved as `v3`), but `.changeset/config.json` still referenced `baseBranch: v4`, which no longer exists — `changeset status`/CI comparisons against the base branch would fail. Point it at `main`.