### PR TITLE
chore: retarget workflows from v4 to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: Build
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main, v4]
+    branches: [main]
   push:
-    branches: [main, v4]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,7 +28,7 @@ jobs:
       - run: pnpm build:tsgo
       - run: pnpm circular
       - name: Create Release Pull Request or Publish
-        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/v4'
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         id: changesets
         uses: changesets/action@v1
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,9 +3,9 @@ name: Check
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main, v4]
+    branches: [main]
   push:
-    branches: [main, v4]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: Test
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main, v4]
+    branches: [main]
   push:
-    branches: [main, v4]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The v4 branch was promoted to `main` (old main preserved as `v3`), but the CI workflows still referenced `v4`:

- `build.yml`/`check.yml`/`test.yml` trigger on `branches: [main, v4]` — harmless but stale
- **`build.yml`'s changesets release step is gated on `refs/heads/v4`**, so pushes to `main` never run `changesets/action` — which is why no Version Packages PR was opened for the 13 pending changesets

Retarget everything at `main`. Once merged, the next Build run on `main` should open the Version Packages (beta) PR.